### PR TITLE
Make plugin data regex as flexible as WP core

### DIFF
--- a/classes/class-plugin-updater.php
+++ b/classes/class-plugin-updater.php
@@ -29,7 +29,7 @@ class GitHub_Plugin_Updater {
 		add_filter( 'extra_plugin_headers', array( $this, 'add_headers' ) );
 
 		$this->config = $this->get_plugin_meta();
-		
+
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'update_available' ) );
 		add_filter( 'upgrader_source_selection', array( $this, 'upgrader_source_selection_filter' ), 10, 3 );
 		add_action( 'http_request_args', array( $this, 'no_ssl_http_request_args' ), 10, 2 );
@@ -49,7 +49,7 @@ class GitHub_Plugin_Updater {
 		$plugins = get_plugins();
 		$i = 0;
 		$arr = array();
-		
+
 		foreach( $plugins as $plugin => $headers ) {
 			if( ! empty($headers['GitHub Plugin URI']) ) {
 				$repo = explode( '/', ltrim( parse_url( $headers['GitHub Plugin URI'], PHP_URL_PATH ), '/' ) );
@@ -156,7 +156,7 @@ class GitHub_Plugin_Updater {
 		if( ! $response )
 			return false;
 
-		preg_match( '#^\s*Version\:\s*(.*)$#im', base64_decode( $response->content ), $matches );
+		preg_match( '/^[ \t\/*#@]*Version\:\s*(.*)$/im', base64_decode( $response->content ), $matches );
 
 		if( ! empty( $matches[1] ) )
 			return $matches[1];
@@ -197,11 +197,11 @@ class GitHub_Plugin_Updater {
 		return $transient;
 	}
 
-	
+
 	/**
 	 *	Github delivers zip files as <Username>-<TagName>.zip
 	 *	must rename this zip file to the accurate plugin folder
-	 * 
+	 *
 	 * @since 1.0
 	 * @param string
 	 * @return string


### PR DESCRIPTION
The updater would only allow zero or more spaces before Version when trying to get the remote version. This PR changes the regex to match the one used on WP `get_file_data()`, which allows zero or more spaces, tabs, asterisks, hashes and at-symbols. This means that plugin file data contained within a DocBlock (therefore starting with a space, an asterisk, then another space before Version), such as found in the [WordPress Plugin Boilerplate](https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate/blob/master/plugin-name/plugin-name.php#L18) project, are recognised by the updater.

I've not changed anything in the theme class, but if that has a similar regex, it would make sense to standardise it.
