### PR TITLE
Return early where possible.

### DIFF
--- a/classes/class-plugin-updater.php
+++ b/classes/class-plugin-updater.php
@@ -298,26 +298,32 @@ class GitHub_Plugin_Updater {
 			}
 		}
 
-		if ( isset( $_GET['action'] ) && in_array( $_GET['action'], $update, true ) ) {
-			if ( isset( $source, $remote_source, $plugin ) && stristr( basename( $source ), $plugin ) ) {
-				$corrected_source = trailingslashit( $remote_source ) . trailingslashit( $plugin );
-				$upgrader->skin->feedback(
-					sprintf(
-						__( 'Renaming %s to %s...', 'github-updater' ),
-						'<span class="code">' . basename( $source ) . '</span>',
-						'<span class="code">' . basename( $corrected_source ) . '</span>'
-					)
-				);
-				if ( $wp_filesystem->move( $source, $corrected_source, true ) ) {
-					$upgrader->skin->feedback( __( 'Rename successful...', 'github-updater' ) );
-					return $corrected_source;
-				} else {
-					$upgrader->skin->feedback( __( 'Unable to rename downloaded plugin.', 'github-updater' ) );
-					return new WP_Error();
-				}
-			}
+		// If there's no action set, or not one we recognise, abort
+		if ( ! isset( $_GET['action'] ) || ! in_array( $_GET['action'], $update, true ) )
+			return $source;
+
+		// If the values aren't set, or it's not a GitHub-sourced plugin, abort
+		if ( ! isset( $source, $remote_source, $plugin ) || false === stristr( basename( $source ), $plugin ) )
+			return $source;
+
+		$corrected_source = trailingslashit( $remote_source ) . trailingslashit( $plugin );
+		$upgrader->skin->feedback(
+			sprintf(
+				__( 'Renaming %s to %s...', 'github-updater' ),
+				'<span class="code">' . basename( $source ) . '</span>',
+				'<span class="code">' . basename( $corrected_source ) . '</span>'
+			)
+		);
+
+		// If we can rename, do so and return the new name
+		if ( $wp_filesystem->move( $source, $corrected_source, true ) ) {
+			$upgrader->skin->feedback( __( 'Rename successful...', 'github-updater' ) );
+			return $corrected_source;
 		}
-		return $source;
+
+		// Otherwise, return an error
+		$upgrader->skin->feedback( __( 'Unable to rename downloaded plugin.', 'github-updater' ) );
+		return new WP_Error();
 	}
 
 	/**

--- a/classes/class-theme-updater.php
+++ b/classes/class-theme-updater.php
@@ -175,7 +175,7 @@ class GitHub_Theme_Updater {
 	 * Github delivers zip files as <Repo>-<Tag>.zip
 	 *
 	 * @since 1.0.0
-	 * 
+	 *
 	 * @global WP_Filesystem $wp_filesystem
 	 *
 	 * @param string $source
@@ -196,26 +196,32 @@ class GitHub_Theme_Updater {
 			}
 		}
 
-		if ( isset( $_GET['action'] ) && in_array( $_GET['action'], $update, true ) ) {
-			if ( isset( $source, $remote_source, $theme ) && stristr( basename( $source ), $theme ) ) {
-				$corrected_source = trailingslashit( $remote_source ) . trailingslashit( $theme );
-				$upgrader->skin->feedback(
-					sprintf(
-						__( 'Renaming %s to %s...', 'github-updater' ),
-						'<span class="code">' . basename( $source ) . '</span>',
-						'<span class="code">' . basename( $corrected_source ) . '</span>'
-					)
-				);
-				if ( $wp_filesystem->move( $source, $corrected_source, true ) ) {
-					$upgrader->skin->feedback( __( 'Rename successful...', 'github-updater' ) );
-					return $corrected_source;
-				} else {
-					$upgrader->skin->feedback( __( 'Unable to rename downloaded theme.', 'github-updater' ) );
-					return new WP_Error();
-				}
-			}
+		// If there's no action set, or not one we recognise, abort
+		if ( ! isset( $_GET['action'] ) || ! in_array( $_GET['action'], $update, true ) )
+			return $source;
+
+		// If the values aren't set, or it's not a GitHub-sourced plugin, abort
+		if ( ! isset( $source, $remote_source, $theme ) || false === stristr( basename( $source ), $theme ) )
+			return $source;
+
+		$corrected_source = trailingslashit( $remote_source ) . trailingslashit( $theme );
+		$upgrader->skin->feedback(
+			sprintf(
+				__( 'Renaming %s to %s...', 'github-updater' ),
+				'<span class="code">' . basename( $source ) . '</span>',
+				'<span class="code">' . basename( $corrected_source ) . '</span>'
+			)
+		);
+
+		// If we can rename, do so and return the new name
+		if ( $wp_filesystem->move( $source, $corrected_source, true ) ) {
+			$upgrader->skin->feedback( __( 'Rename successful...', 'github-updater' ) );
+			return $corrected_source;
 		}
-		return $source;
+
+		// Otherwise, return an error
+		$upgrader->skin->feedback( __( 'Unable to rename downloaded theme.', 'github-updater' ) );
+		return new WP_Error();
 	}
 
 	/**


### PR DESCRIPTION
Avoid multiple nesting of conditionals that cover the rest of the method by checking for the conditional inverse and returning early where possible. This makes the code easier to follow and understand.

Follows-up on 80c5fba323f5a72ef84f529949f4701b67c47beb
