### PR TITLE
Don't overwrite headers added by other plugins

### DIFF
--- a/classes/class-plugin-updater.php
+++ b/classes/class-plugin-updater.php
@@ -59,7 +59,10 @@ class GitHub_Plugin_Updater {
 	 * @since 1.0.0
 	 */
 	public function add_headers( $extra_headers ) {
-		$extra_headers = array( 'GitHub Plugin URI', 'GitHub Access Token', 'GitHub Branch' );
+		$extra_headers[] = 'GitHub Plugin URI';
+		$extra_headers[] = 'GitHub Access Token';
+		$extra_headers[] = 'GitHub Branch';
+
 		return $extra_headers;
 	}
 

--- a/classes/class-theme-updater.php
+++ b/classes/class-theme-updater.php
@@ -45,7 +45,8 @@ class GitHub_Theme_Updater {
 	 * @return array
 	 */
 	public function add_headers( $extra_headers ) {
-		$extra_headers = array( 'GitHub Theme URI' );
+		$extra_headers[] = 'GitHub Theme URI';
+
 		return $extra_headers;
 	}
 


### PR DESCRIPTION
`GitHub_Plugin_Updater::add_headers` and `GitHub_Theme_Updater::add_headers` are overwriting the array passed to the filter. This will cause headers added by other plugins and themes to be removed. Instead of overwriting, the function should append.
