### PR TITLE
add checks to avoid conflicts

### DIFF
--- a/github-updater.php
+++ b/github-updater.php
@@ -29,11 +29,27 @@ if ( ! defined( 'WPINC' ) ) {
 
 // Load base classes and Launch
 if ( is_admin() && ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {
-	require_once 'includes/class-github-updater.php';
-	require_once 'includes/class-github-api.php';
-	require_once 'includes/class-bitbucket-api.php';
-	require_once 'includes/class-plugin-updater.php';
-	require_once 'includes/class-theme-updater.php';
+
+	// Load the GitHub_Updater class if it does not already exist. 
+	if ( !class_exists( 'GitHub_Updater' ) )
+		require_once 'includes/class-github-updater.php';
+
+	// Load the GitHub_Updater_GitHub_API class if it does not already exist.
+	if ( !class_exists( 'GitHub_Updater_GitHub_API' ) )
+		require_once 'includes/class-github-api.php';
+
+	// Load the GitHub_Updater_BitBucket_API class if it does not already exist.
+	if ( !class_exists( 'GitHub_Updater_BitBucket_API' ) )
+		require_once 'includes/class-bitbucket-api.php';
+
+	// Load the GitHub_Plugin_Updater class if it does not already exist.
+	if ( !class_exists( 'GitHub_Plugin_Updater' ) )
+		require_once 'includes/class-plugin-updater.php';
+
+	// Load the GitHub_Theme_Updater class if it does not already exist.
+	if ( !class_exists( 'GitHub_Theme_Updater' ) )
+		require_once 'includes/class-theme-updater.php';
+
 	new GitHub_Plugin_Updater;
 	new GitHub_Theme_Updater;
 }

--- a/includes/markdown.php
+++ b/includes/markdown.php
@@ -56,19 +56,21 @@ define( 'MARKDOWNEXTRA_VERSION',  "1.2.8" ); # 29 Nov 2013
 
 @define( 'MARKDOWN_PARSER_CLASS',  'MarkdownExtra_Parser' );
 
-function Markdown($text) {
-#
-# Initialize the parser and return the result of its transform method.
-#
-	# Setup static parser variable.
-	static $parser;
-	if (!isset($parser)) {
-		$parser_class = MARKDOWN_PARSER_CLASS;
-		$parser = new $parser_class;
-	}
+if ( !function_exists( 'Markdown' ) ) { // Add conditional to avoid conflict with other WP plugins.
+	function Markdown($text) {
+	#
+	# Initialize the parser and return the result of its transform method.
+	#
+		# Setup static parser variable.
+		static $parser;
+		if (!isset($parser)) {
+			$parser_class = MARKDOWN_PARSER_CLASS;
+			$parser = new $parser_class;
+		}
 
-	# Transform text using parser.
-	return $parser->transform($text);
+		# Transform text using parser.
+		return $parser->transform($text);
+	}
 }
 
 


### PR DESCRIPTION
I had a client today that was using another WordPress plugin which was also defining a `Markdown` function so I had to do this little mod.
I added some checks for the generic classes as well to avoid conflicts in case a plugin/theme dev embeds these in their own theme/plugin.
Just in case... doesn't hurt to check. :smile: 
