### PR TITLE
Allow other non-github HTTP requests to use basic authentication.

### DIFF
--- a/includes/class-github-api.php
+++ b/includes/class-github-api.php
@@ -25,7 +25,7 @@ class GitHub_Updater_GitHub_API extends GitHub_Updater {
 		$this->type  = $type;
 		self::$hours = 12;
 
-		add_filter( 'http_request_args', array( $this, 'never_authenticate_http' ), 10 );
+		add_filter( 'http_request_args', array( $this, 'never_authenticate_http' ), 10, 2 );
 	}
 
 	/**
@@ -340,10 +340,10 @@ class GitHub_Updater_GitHub_API extends GitHub_Updater {
 	 *
 	 * @return mixed
 	 */
-	public function never_authenticate_http( $args ) {
+	public function never_authenticate_http( $args, $url ) {
 		// Exit if on other APIs use HTTP Authorization
 		if ( isset( $args['headers']['Authorization'] ) ) {
-			if ( false !== strpos( $args['headers']['Authorization'], 'JETPACK' ) ) {
+			if ( false === strpos( $url, 'github.com' ) ) {
 				return $args;
 			}
 			unset( $args['headers']['Authorization'] );


### PR DESCRIPTION
It took me a while to figure out why HTTP requests from other plugins that use basic authentication were failing. 

It looks like an exception was made for Jetpack, but all other plugins will still fall prey to the issue.

Take this request as a naive attempt at fix, asking if it's possible to only apply the restriction to github.com URLs and thus allow other requests to do their thing?
