### PR TITLE
Support for custom `wp-content` folder name

### DIFF
--- a/src/Git_Updater/Plugin.php
+++ b/src/Git_Updater/Plugin.php
@@ -197,7 +197,9 @@ class Plugin {
 			$git_plugin['release_asset']           = $header['release_asset'];
 			$git_plugin['broken']                  = ( empty( $header['owner'] ) || empty( $header['repo'] ) );
 
-			preg_match( '/\/wp-content.*/', $git_plugin['local_path'], $matches );
+			$wp_content_dir = basename(WP_CONTENT_DIR);
+      preg_match( "/\/$wp_content_dir.*/", $git_plugin['local_path'], $matches );
+      
 			$git_plugin['banners']['high'] =
 				file_exists( $git_plugin['local_path'] . 'assets/banner-1544x500.png' )
 					? home_url() . $matches[0] . 'assets/banner-1544x500.png'


### PR DESCRIPTION
`preg_match( '/\/wp-content.*/' ...` would lead to empty `$matches` when using a custom wp-content location, resulting in a lot of `undefined offset` when checking for `$matches[{{offset}}]`.

`WP_CONTENT_DIR` is always defined (see `wp-includes/default-constants.php`, line 71), so we can safely rely on it as described [on the official codex](https://codex.wordpress.org/Determining_Plugin_and_Content_Directories#Constants):
```php
if ( ! defined( 'WP_CONTENT_DIR' ) ) {
  define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' );
}
```