### PR TITLE
Updated function_exists calls to check the current namespace

### DIFF
--- a/src/Git_Updater/Base.php
+++ b/src/Git_Updater/Base.php
@@ -520,7 +520,7 @@ class Base {
 		$new_source = $this->fix_misnamed_directory( $new_source, $remote_source, $upgrader_object, $slug );
 
 		if ( $source !== $new_source ) {
-			if ( function_exists( 'move_dir' ) ) {
+			if ( function_exists( __NAMESPACE__ . '\move_dir' ) ) {
 				$result = \move_dir( $source, $new_source );
 			} else {
 				new Shim();

--- a/src/Git_Updater/GU_Freemius.php
+++ b/src/Git_Updater/GU_Freemius.php
@@ -29,7 +29,7 @@ class GU_Freemius {
 	 * @return array|void
 	 */
 	public function init() {
-		if ( ! function_exists( 'gu_fs' ) ) {
+		if ( ! function_exists( __NAMESPACE__ . '\gu_fs' ) ) {
 
 			/**
 			 * Create a helper function for easy SDK access.


### PR DESCRIPTION
## Description
Updates the `function_exists` checks of two functions to check within the namespaces they're declared. Currently, the checks are looking for them in the global namespace, making it possible for the check to fail and the function to be redeclared.

## Motivation and Discovery
We ran across this problem specifically with the `gu_fs` function. A theme was installed that was explicitly triggering the `plugins_loaded` hook, causing the plugins_loaded logic to run twice, once during the normal execution of WordPress, and again because of the explicit call. 

Within the `Fragen\Git_Updater\GU_Freemius\init()` function call, the line `gu_fs` function declaration is wrapped within the line `if ( ! function_exists( 'gu_fs' ) )`. This is checking to see if the function exists within the global namespace and returns `false` when this function is first called. When the function is called a second time, due to the explicit triggering of `plugins_loaded` within a theme in this case, the check returns `false` the second time as well, because the function exists within the `Fragen\Git_Updater` namespace and not within the global namespace.

This change will ensure the function is not redeclared, even if the `plugins_loaded` function is improperly called a second time.