### PR TITLE
Limit PHPUnit Polyfills to 1.x.

### DIFF
--- a/.github/workflows/wp-phpunit.yml
+++ b/.github/workflows/wp-phpunit.yml
@@ -43,7 +43,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           coverage: none
           extensions: mysql, mysqli
-          tools: composer, wp-cli, phpunit-polyfills
+          tools: composer, wp-cli, phpunit-polyfills:1.0
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/wp-phpunit.yml
+++ b/.github/workflows/wp-phpunit.yml
@@ -43,7 +43,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           coverage: none
           extensions: mysql, mysqli
-          tools: composer, wp-cli, phpunit-polyfills, phpunit
+          tools: composer, wp-cli, phpunit-polyfills
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
[PHPUnit Polyfills](https://github.com/Yoast/PHPUnit-Polyfills/) recently updated to 2.0.0 which added PHPUnit 10 support.

The [release announcement](https://github.com/Yoast/PHPUnit-Polyfills/releases/tag/2.0.0) states:
> Projects which don't use any of the new or removed functionality in their test suite, can, of course, use the PHPUnit Polyfills 1.x and 2.x series side-by-side, like so `composer require --dev yoast/phpunit-polyfills:"^1.0 || ^2.0"`

As Git Updater doesn't use `composer.json` to install PHPUnit Polyfills, but rather the `tools` input for the [shivammathur/setup-php](https://github.com/shivammathur/setup-php) GitHub action, this PR updates the `tools` value with `phpunit-polyfills:1.0`, based on the `shivammathur/setup-php` documentation.

> When you specify just the major version or the version in `major.minor` format, the latest patch version matching the input will be setup.
> Reference: ["tools" support](https://github.com/shivammathur/setup-php#wrench-tools-support)

The PR also removes `phpunit` from the `tools` value, as `phpunit-polyfills` installs PHPUnit anyway.