### PR TITLE
Add title (hover) text to `plugins.php` icon, "Updates via Git Updater"

### DIFF
--- a/src/Git_Updater/Base.php
+++ b/src/Git_Updater/Base.php
@@ -699,7 +699,8 @@ class Base {
 				$githost = str_replace( "{$type_cap}URI", '', $key );
 				$padding = is_rtl() ? 'padding-left: 6px;' : 'padding-right: 6px;';
 				$icon    = sprintf(
-					'<img src="%1$s" style="vertical-align:text-bottom;%2$s" height="16" width="16" alt="%3$s" />',
+					'<img title="%1$s" src="%2$s" style="vertical-align:text-bottom;%3$s" height="16" width="16" alt="%4$s" />',
+					__( 'Updates via Git Updater', 'git-updater' ),
 					plugins_url( $git['icons'][ strtolower( $githost ) ] ),
 					$add_padding ? $padding : '',
 					$githost


### PR DESCRIPTION
Add "Updates via Git Updater" to the GitHub icon on `plugins.php`.

----

<img width="525" alt="Screenshot 2023-09-08 at 7 34 46 PM" src="https://github.com/afragen/git-updater/assets/4720401/598e6571-7df4-4539-a750-d22091e500e5">

----


So, I have a plugin which also uses the GitHub icon on `plugins.php` and I thought my site had gone mad because I removed my plugin but the GitHub icon persisted! I searched and searched and considered asking for help, until I eventually realised that your plugin was adding the same icon! 

https://github.com/BrianHenryIE/bh-wp-plugins-page