### PR TITLE
Suggestion: Move the plugins.php GitHub icon to the auto-updates column

### DIFF
--- a/src/Git_Updater/Base.php
+++ b/src/Git_Updater/Base.php
@@ -621,6 +621,8 @@ class Base {
 	/**
 	 * Add git host based icons.
 	 *
+	 * @hooked theme_row_meta
+	 *
 	 * @param array  $links Row meta action links.
 	 * @param string $file  Plugin or theme file.
 	 *
@@ -633,6 +635,21 @@ class Base {
 		}
 
 		return $links;
+	}
+
+	/**
+	 * Append the GitHub icon to the auto-updates column text.
+	 *
+	 * @hooked plugin_auto_update_setting_html
+	 * @see \WP_Plugins_List_Table::single_row()
+	 *
+	 * @param string $html The existing HTML for the plugins.php Automatic Updates column.
+	 * @param string $file Plugin or theme file.
+	 *
+	 * @return string
+	 */
+	public function plugin_auto_update_setting_html( $html, $file ) {
+		return $html . ' | ' . $this->get_git_icon( $file, false );
 	}
 
 	/**

--- a/src/Git_Updater/Base.php
+++ b/src/Git_Updater/Base.php
@@ -649,7 +649,11 @@ class Base {
 	 * @return string
 	 */
 	public function plugin_auto_update_setting_html( $html, $file ) {
-		return $html . ' | ' . $this->get_git_icon( $file, false );
+		$icon = $this->get_git_icon( $file, false );
+		if( is_null( $icon ) ) {
+			return $html;
+		}
+		return "{$html} | {$icon}";
 	}
 
 	/**

--- a/src/Git_Updater/Init.php
+++ b/src/Git_Updater/Init.php
@@ -92,7 +92,7 @@ class Init {
 		add_filter( 'upgrader_source_selection', [ $this->base, 'upgrader_source_selection' ], 10, 4 );
 
 		// Add git host icons.
-		add_filter( 'plugin_row_meta', [ $this->base, 'row_meta_icons' ], 15, 2 );
+		add_filter( 'plugin_auto_update_setting_html', [ $this->base, 'plugin_auto_update_setting_html' ], 15, 2 );
 		add_filter( 'theme_row_meta', [ $this->base, 'row_meta_icons' ], 15, 2 );
 
 		// Check for deletion of cron event.


### PR DESCRIPTION
Change:

<img width="1167" alt="Screenshot 2023-09-10 at 3 44 27 PM" src="https://github.com/afragen/git-updater/assets/4720401/9891258c-18a5-4ca4-8761-ef2e6fcc37ed">

to:

<img width="1149" alt="Screenshot 2023-09-10 at 3 50 36 PM" src="https://github.com/afragen/git-updater/assets/4720401/16245ddd-98f6-439e-aae6-ee790a5c0747">

The icon is currently added to the `plugin_row_meta` list. This instead appends it to the `plugin_auto_update_setting_html` (there is no filter for the array of items).

Personally, I consider the first column (actions) to be links internal to the site, the second (meta) to be external links, and since the relatively new third column's topic is automatic updates, it seems appropriate for an icon representing an updates function.