### PR TITLE
Separate format specifier to prevent php warning message

### DIFF
--- a/src/Git_Updater/Bootstrap.php
+++ b/src/Git_Updater/Bootstrap.php
@@ -71,7 +71,7 @@ class Bootstrap {
 
 		$message = sprintf(
 			/* translators: %1: opening tag, %2: closing tag */
-			__( 'Git Updater is missing required composer dependencies. %1$sLearn more.%2$s', 'git-updater' ),
+			__( 'Git Updater is missing required composer dependencies. %1$s Learn more.%2$s', 'git-updater' ),
 			'<a href="https://github.com/afragen/git-updater/wiki/Installation" target="_blank" rel="noreferrer">',
 			'</a>'
 		);

--- a/src/Git_Updater/Branch.php
+++ b/src/Git_Updater/Branch.php
@@ -322,7 +322,7 @@ class Branch {
 		if ( '1' === self::$options['branch_switch'] ) {
 			printf(
 				/* translators: 1: branch name, 2: jQuery dropdown, 3: closing tag */
-				'<p>' . esc_html__( 'Current branch is `%1$s`, try %2$sanother version%3$s', 'git-updater-pro' ),
+				'<p>' . esc_html__( 'Current branch is `%1$s`, try %2$s another version%3$s', 'git-updater-pro' ),
 				esc_attr( $theme->branch ),
 				'<a href="#" onclick="jQuery(\'#gu_versions\').toggle();return false;">',
 				'</a>.</p>'
@@ -424,7 +424,7 @@ class Branch {
 		echo wp_kses_post( $this->base->get_git_icon( $file, true ) );
 		printf(
 			/* translators: 1: branch name, 2: jQuery dropdown, 3: closing tag */
-			esc_html__( 'Current branch is `%1$s`, try %2$sanother version%3$s', 'git-updater-pro' ),
+			esc_html__( 'Current branch is `%1$s`, try %2$s another version%3$s', 'git-updater-pro' ),
 			esc_attr( $data['branch'] ),
 			'<a href="#" onclick="jQuery(\'#' . esc_attr( $data['id'] ) . '\').toggle();return false;">',
 			'</a>.'

--- a/src/Git_Updater/Theme.php
+++ b/src/Git_Updater/Theme.php
@@ -402,7 +402,7 @@ class Theme {
 			} else {
 				printf(
 					/* translators: 1: version number, 2: closing anchor tag, 3: update URL */
-					esc_html__( 'View version %1$s details%2$s or %3$supdate now%2$s.', 'git-updater' ),
+					esc_html__( 'View version %1$s details%2$s or %3$s update now%2$s.', 'git-updater' ),
 					esc_attr( $response['new_version'] ),
 					'</a>',
 					sprintf(
@@ -518,7 +518,7 @@ class Theme {
 					if ( ! empty( $current->response[ $theme->slug ]['package'] ) ) {
 						printf(
 							/* translators: 1: version number, 2: closing anchor tag, 3: update URL */
-							esc_html__( 'View version %1$s details%2$s or %3$supdate now%2$s.', 'git-updater' ),
+							esc_html__( 'View version %1$s details%2$s or %3$s update now%2$s.', 'git-updater' ),
 							$theme->remote_version = isset( $theme->remote_version ) ? esc_attr( $theme->remote_version ) : null,
 							'</a>',
 							sprintf(
@@ -536,7 +536,7 @@ class Theme {
 						);
 						printf(
 							/* translators: %s: opening/closing paragraph and italic tags */
-							esc_html__( '%1$sAutomatic update is unavailable for this theme.%2$s', 'git-updater' ),
+							esc_html__( '%1$s Automatic update is unavailable for this theme.%2$s', 'git-updater' ),
 							'<p><i>',
 							'</i></p>'
 						);

--- a/vendor/afragen/wp-dependency-installer/wp-dependency-installer.php
+++ b/vendor/afragen/wp-dependency-installer/wp-dependency-installer.php
@@ -841,7 +841,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 			 */
 			if ( apply_filters( 'wp_dependency_required_label', true ) ) {
 				/* translators: %s: opening and closing span tags */
-				$actions = array_merge( [ 'required-plugin' => sprintf( esc_html__( '%1$sRequired Plugin%2$s' ), '<span class="network_active" style="font-variant-caps: small-caps;">', '</span>' ) ], $actions );
+				$actions = array_merge( [ 'required-plugin' => sprintf( esc_html__( '%1$s Required Plugin%2$s' ), '<span class="network_active" style="font-variant-caps: small-caps;">', '</span>' ) ], $actions );
 			}
 
 			return $actions;

--- a/vendor/freemius/wordpress-sdk/includes/class-freemius.php
+++ b/vendor/freemius/wordpress-sdk/includes/class-freemius.php
@@ -21595,7 +21595,7 @@
                             ($this->has_free_plan() ?
                                 sprintf( $this->get_text_inline( 'Your license has expired. You can still continue using the free %s forever.', 'license-expired-blocking-message' ), $this->_module_type ) :
                                 /* translators: %1$s: product title; %2$s, %3$s: wrapping HTML anchor element; %4$s: 'plugin', 'theme', or 'add-on'. */
-                                sprintf( $this->get_text_inline( 'Your license has expired. %1$sUpgrade now%2$s to continue using the %3$s without interruptions.', 'license-expired-blocking-message_premium-only' ), sprintf('<a href="%s">', $this->pricing_url()), '</a>', $this->get_module_label(true) ) ),
+                                sprintf( $this->get_text_inline( 'Your license has expired. %1$s Upgrade now%2$s to continue using the %3$s without interruptions.', 'license-expired-blocking-message_premium-only' ), sprintf('<a href="%s">', $this->pricing_url()), '</a>', $this->get_module_label(true) ) ),
                             'license_expired',
                             $hmm_text
                         );
@@ -21644,7 +21644,7 @@
                             ($this->has_free_plan() ?
                                 $this->get_text_inline( 'Your free trial has expired. You can still continue using all our free features.', 'trial-expired-message' ) :
                                 /* translators: %1$s: product title; %2$s, %3$s: wrapping HTML anchor element; %4$s: 'plugin', 'theme', or 'add-on'. */
-                                sprintf( $this->get_text_inline( 'Your free trial has expired. %1$sUpgrade now%2$s to continue using the %3$s without interruptions.', 'trial-expired-message_premium-only' ), sprintf('<a href="%s">', $this->pricing_url()), '</a>', $this->get_module_label(true))),
+                                sprintf( $this->get_text_inline( 'Your free trial has expired. %1$s Upgrade now%2$s to continue using the %3$s without interruptions.', 'trial-expired-message_premium-only' ), sprintf('<a href="%s">', $this->pricing_url()), '</a>', $this->get_module_label(true))),
                             'trial_expired',
                             $hmm_text
                         );


### PR DESCRIPTION
### Description
This pull request addresses the issue with format specifiers in some messages, which caused warnings and even fatal errors. The fix separates the format specifier to ensure proper argument handling in the printf function.

### Problem
- Warnings and fatal errors were encountered due to incorrect format specifier usage in the printf function.
- Screenshots of the warnings and errors are attached below.

### Solution
- Corrected the format specifier by ensuring each placeholder is properly formatted and all necessary arguments are provided.

### Before
![image](https://github.com/afragen/git-updater/assets/8497431/0d63b43f-1124-4e69-b452-0aff08b4131a)
![image](https://github.com/afragen/git-updater/assets/8497431/d8154aeb-55a5-475a-8868-10f79a621e10)

### After
The issue is resolved with no warnings or errors after applying the fix.

### Testing
- Tested the changes locally and at a stanging env and verified that the theme update message displays correctly without any warnings or errors.


Please review the changes and merge them into the main branch.

