### PR TITLE
fix: guard cron scheduling to main site only in multisite (#1137)

### DIFF
--- a/.github/workflows/wp-phpunit.yml
+++ b/.github/workflows/wp-phpunit.yml
@@ -58,7 +58,11 @@ jobs:
       - name: Install WP Tests
         run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest
 
-      - name: PHPUnit tests
+      - name: PHPUnit tests (single site)
         run: |
           echo "define('WP_TESTS_PHPUNIT_POLYFILLS_PATH', '$HOME/.composer/vendor/yoast/phpunit-polyfills');" >> /tmp/wordpress-tests-lib/wp-tests-config.php
           phpunit --config=phpunit.xml
+
+      - name: PHPUnit tests (multisite)
+        run: |
+          WP_MULTISITE=1 phpunit --config=phpunit.xml

--- a/src/Git_Updater/GU_Upgrade.php
+++ b/src/Git_Updater/GU_Upgrade.php
@@ -151,6 +151,10 @@ final class GU_Upgrade {
 	 * @return void
 	 */
 	private function schedule_access_token_cleanup() {
+		if ( is_multisite() && ! is_main_site() ) {
+			return;
+		}
+
 		if ( false === wp_next_scheduled( 'gu_delete_access_tokens' ) ) {
 			wp_schedule_event( time() + \MONTH_IN_SECONDS, 'twicedaily', 'gu_delete_access_tokens' );
 		}

--- a/src/Git_Updater/Traits/GU_Trait.php
+++ b/src/Git_Updater/Traits/GU_Trait.php
@@ -293,7 +293,9 @@ trait GU_Trait {
 
 		$wpdb->query( $wpdb->prepare( $delete_string, [ '%ghu-%' ] ) ); // phpcs:ignore
 
-		wp_cron();
+		if ( ! is_multisite() || is_main_site() ) {
+			wp_cron();
+		}
 
 		return true;
 	}

--- a/tests/test-multisite-cron-guard.php
+++ b/tests/test-multisite-cron-guard.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Test multisite cron guard logic.
+ *
+ * Tests for:
+ * - GU_Upgrade::schedule_access_token_cleanup() — early return on subsites.
+ * - GU_Trait::delete_all_cached_data() — wp_cron() skipped on subsites.
+ *
+ * Run with WP_TESTS_MULTISITE=true to exercise the multisite code paths.
+ * In single-site mode, the guards pass through and behavior is unchanged.
+ *
+ * @package Git_Updater
+ */
+
+/**
+ * Helper class to expose the private schedule_access_token_cleanup() method.
+ *
+ * GU_Upgrade is declared final, so we use a thin wrapper that delegates
+ * to a reflection call. This avoids modifying production code visibility.
+ */
+class Test_Multisite_Cron_Guard extends \WP_UnitTestCase {
+
+	use Fragen\Git_Updater\Traits\GU_Trait;
+
+	/**
+	 * Clean up cron events after each test.
+	 */
+	public function tear_down() {
+		wp_clear_scheduled_hook( 'gu_delete_access_tokens' );
+		parent::tear_down();
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| GU_Trait::delete_all_cached_data() — wp_cron() guard
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * On a single site, delete_all_cached_data() should call wp_cron().
+	 *
+	 * We verify indirectly: wp_cron() processes due cron events, so we
+	 * schedule a test action, call delete_all_cached_data(), and check
+	 * whether the action fired.
+	 */
+	public function test_delete_all_cached_data_calls_wp_cron_on_single_site() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Single-site test — skipped under multisite.' );
+		}
+
+		$fired = false;
+		add_action(
+			'gu_test_cron_action',
+			function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		// Schedule an event in the past so wp_cron() will execute it.
+		wp_schedule_single_event( time() - 1, 'gu_test_cron_action' );
+
+		$result = $this->delete_all_cached_data();
+
+		$this->assertTrue( $result, 'delete_all_cached_data() should return true.' );
+		$this->assertTrue( $fired, 'wp_cron() should fire on single-site, executing due events.' );
+
+		// Clean up.
+		wp_clear_scheduled_hook( 'gu_test_cron_action' );
+	}
+
+	/**
+	 * On the main site of a multisite network, delete_all_cached_data()
+	 * should call wp_cron().
+	 *
+	 * @group multisite
+	 */
+	public function test_delete_all_cached_data_calls_wp_cron_on_main_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite test — skipped under single-site.' );
+		}
+
+		// Ensure we're on the main site.
+		switch_to_blog( get_main_site_id() );
+
+		$fired = false;
+		add_action(
+			'gu_test_cron_action',
+			function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		wp_schedule_single_event( time() - 1, 'gu_test_cron_action' );
+
+		$result = $this->delete_all_cached_data();
+
+		$this->assertTrue( $result, 'delete_all_cached_data() should return true.' );
+		$this->assertTrue( $fired, 'wp_cron() should fire on the main site of a multisite network.' );
+
+		wp_clear_scheduled_hook( 'gu_test_cron_action' );
+		restore_current_blog();
+	}
+
+	/**
+	 * On a subsite of a multisite network, delete_all_cached_data()
+	 * should NOT call wp_cron().
+	 *
+	 * @group multisite
+	 */
+	public function test_delete_all_cached_data_skips_wp_cron_on_subsite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite test — skipped under single-site.' );
+		}
+
+		// Create a subsite and switch to it.
+		$blog_id = self::factory()->blog->create();
+		switch_to_blog( $blog_id );
+
+		$this->assertFalse( is_main_site(), 'Should be on a subsite.' );
+
+		$fired = false;
+		add_action(
+			'gu_test_cron_action',
+			function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		wp_schedule_single_event( time() - 1, 'gu_test_cron_action' );
+
+		$result = $this->delete_all_cached_data();
+
+		$this->assertTrue( $result, 'delete_all_cached_data() should still return true.' );
+		$this->assertFalse( $fired, 'wp_cron() should NOT fire on a subsite.' );
+
+		wp_clear_scheduled_hook( 'gu_test_cron_action' );
+		restore_current_blog();
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| GU_Upgrade::schedule_access_token_cleanup() — multisite guard
+	|--------------------------------------------------------------------------
+	|
+	| schedule_access_token_cleanup() is private, so we test it indirectly
+	| by checking whether the cron event gets scheduled after construction
+	| scenarios. We use reflection to invoke the private method.
+	*/
+
+	/**
+	 * Get a GU_Upgrade instance and invoke schedule_access_token_cleanup().
+	 *
+	 * @return void
+	 */
+	private function invoke_schedule_access_token_cleanup() {
+		$upgrade    = new Fragen\Git_Updater\GU_Upgrade();
+		$reflection = new ReflectionMethod( $upgrade, 'schedule_access_token_cleanup' );
+		$reflection->setAccessible( true );
+		$reflection->invoke( $upgrade );
+	}
+
+	/**
+	 * On a single site, schedule_access_token_cleanup() should schedule
+	 * the gu_delete_access_tokens cron event.
+	 */
+	public function test_schedule_access_token_cleanup_schedules_on_single_site() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Single-site test — skipped under multisite.' );
+		}
+
+		// Ensure no pre-existing event.
+		wp_clear_scheduled_hook( 'gu_delete_access_tokens' );
+		$this->assertFalse( wp_next_scheduled( 'gu_delete_access_tokens' ), 'Precondition: no event scheduled.' );
+
+		$this->invoke_schedule_access_token_cleanup();
+
+		$this->assertNotFalse(
+			wp_next_scheduled( 'gu_delete_access_tokens' ),
+			'gu_delete_access_tokens should be scheduled on single-site.'
+		);
+	}
+
+	/**
+	 * On the main site of a multisite network, schedule_access_token_cleanup()
+	 * should schedule the cron event.
+	 *
+	 * @group multisite
+	 */
+	public function test_schedule_access_token_cleanup_schedules_on_main_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite test — skipped under single-site.' );
+		}
+
+		switch_to_blog( get_main_site_id() );
+		wp_clear_scheduled_hook( 'gu_delete_access_tokens' );
+
+		$this->invoke_schedule_access_token_cleanup();
+
+		$this->assertNotFalse(
+			wp_next_scheduled( 'gu_delete_access_tokens' ),
+			'gu_delete_access_tokens should be scheduled on the main site.'
+		);
+
+		restore_current_blog();
+	}
+
+	/**
+	 * On a subsite of a multisite network, schedule_access_token_cleanup()
+	 * should NOT schedule the cron event.
+	 *
+	 * @group multisite
+	 */
+	public function test_schedule_access_token_cleanup_skips_on_subsite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite test — skipped under single-site.' );
+		}
+
+		$blog_id = self::factory()->blog->create();
+		switch_to_blog( $blog_id );
+
+		$this->assertFalse( is_main_site(), 'Should be on a subsite.' );
+
+		wp_clear_scheduled_hook( 'gu_delete_access_tokens' );
+		$this->assertFalse( wp_next_scheduled( 'gu_delete_access_tokens' ), 'Precondition: no event scheduled.' );
+
+		$this->invoke_schedule_access_token_cleanup();
+
+		$this->assertFalse(
+			wp_next_scheduled( 'gu_delete_access_tokens' ),
+			'gu_delete_access_tokens should NOT be scheduled on a subsite.'
+		);
+
+		restore_current_blog();
+	}
+}

--- a/tests/test-multisite-cron-guard.php
+++ b/tests/test-multisite-cron-guard.php
@@ -13,20 +13,22 @@
  */
 
 /**
- * Helper class to expose the private schedule_access_token_cleanup() method.
+ * Class Test_Multisite_Cron_Guard
  *
- * GU_Upgrade is declared final, so we use a thin wrapper that delegates
- * to a reflection call. This avoids modifying production code visibility.
+ * Uses the GU_Trait directly and invokes GU_Upgrade's private method
+ * via reflection (GU_Upgrade is final, so we cannot extend it).
  */
 class Test_Multisite_Cron_Guard extends \WP_UnitTestCase {
 
 	use Fragen\Git_Updater\Traits\GU_Trait;
 
 	/**
-	 * Clean up cron events after each test.
+	 * Clean up cron events and filters after each test.
 	 */
 	public function tear_down() {
 		wp_clear_scheduled_hook( 'gu_delete_access_tokens' );
+		wp_clear_scheduled_hook( 'gu_test_cron_action' );
+		remove_all_filters( 'cron_request' );
 		parent::tear_down();
 	}
 
@@ -39,33 +41,45 @@ class Test_Multisite_Cron_Guard extends \WP_UnitTestCase {
 	/**
 	 * On a single site, delete_all_cached_data() should call wp_cron().
 	 *
-	 * We verify indirectly: wp_cron() processes due cron events, so we
-	 * schedule a test action, call delete_all_cached_data(), and check
-	 * whether the action fired.
+	 * We verify by hooking into the 'cron_request' filter, which fires
+	 * inside spawn_cron() when wp_cron() reaches the point of spawning
+	 * the loopback request. In the test environment there is no HTTP
+	 * server, so we short-circuit the request and just record that the
+	 * code path was reached.
 	 */
 	public function test_delete_all_cached_data_calls_wp_cron_on_single_site() {
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'Single-site test — skipped under multisite.' );
 		}
 
-		$fired = false;
-		add_action(
-			'gu_test_cron_action',
-			function () use ( &$fired ) {
-				$fired = true;
-			}
+		$spawn_attempted = false;
+		add_filter(
+			'cron_request',
+			function ( $cron_request ) use ( &$spawn_attempted ) {
+				$spawn_attempted = true;
+				// Return a blocking request with a very short timeout to
+				// prevent an actual HTTP call in the test environment.
+				$cron_request['args']['blocking'] = false;
+				$cron_request['args']['timeout']  = 0.01;
+				return $cron_request;
+			},
+			9999
 		);
 
-		// Schedule an event in the past so wp_cron() will execute it.
+		// Schedule an event in the past so wp_cron() has something to process.
 		wp_schedule_single_event( time() - 1, 'gu_test_cron_action' );
+
+		// Clear the spawn-cron lock so wp_cron() doesn't bail early.
+		delete_transient( 'doing_cron' );
 
 		$result = $this->delete_all_cached_data();
 
 		$this->assertTrue( $result, 'delete_all_cached_data() should return true.' );
-		$this->assertTrue( $fired, 'wp_cron() should fire on single-site, executing due events.' );
+		$this->assertTrue( $spawn_attempted, 'wp_cron() should attempt to spawn cron on single-site.' );
 
 		// Clean up.
 		wp_clear_scheduled_hook( 'gu_test_cron_action' );
+		remove_all_filters( 'cron_request' );
 	}
 
 	/**
@@ -82,22 +96,28 @@ class Test_Multisite_Cron_Guard extends \WP_UnitTestCase {
 		// Ensure we're on the main site.
 		switch_to_blog( get_main_site_id() );
 
-		$fired = false;
-		add_action(
-			'gu_test_cron_action',
-			function () use ( &$fired ) {
-				$fired = true;
-			}
+		$spawn_attempted = false;
+		add_filter(
+			'cron_request',
+			function ( $cron_request ) use ( &$spawn_attempted ) {
+				$spawn_attempted = true;
+				$cron_request['args']['blocking'] = false;
+				$cron_request['args']['timeout']  = 0.01;
+				return $cron_request;
+			},
+			9999
 		);
 
 		wp_schedule_single_event( time() - 1, 'gu_test_cron_action' );
+		delete_transient( 'doing_cron' );
 
 		$result = $this->delete_all_cached_data();
 
 		$this->assertTrue( $result, 'delete_all_cached_data() should return true.' );
-		$this->assertTrue( $fired, 'wp_cron() should fire on the main site of a multisite network.' );
+		$this->assertTrue( $spawn_attempted, 'wp_cron() should attempt to spawn cron on the main site.' );
 
 		wp_clear_scheduled_hook( 'gu_test_cron_action' );
+		remove_all_filters( 'cron_request' );
 		restore_current_blog();
 	}
 
@@ -118,22 +138,28 @@ class Test_Multisite_Cron_Guard extends \WP_UnitTestCase {
 
 		$this->assertFalse( is_main_site(), 'Should be on a subsite.' );
 
-		$fired = false;
-		add_action(
-			'gu_test_cron_action',
-			function () use ( &$fired ) {
-				$fired = true;
-			}
+		$spawn_attempted = false;
+		add_filter(
+			'cron_request',
+			function ( $cron_request ) use ( &$spawn_attempted ) {
+				$spawn_attempted = true;
+				$cron_request['args']['blocking'] = false;
+				$cron_request['args']['timeout']  = 0.01;
+				return $cron_request;
+			},
+			9999
 		);
 
 		wp_schedule_single_event( time() - 1, 'gu_test_cron_action' );
+		delete_transient( 'doing_cron' );
 
 		$result = $this->delete_all_cached_data();
 
 		$this->assertTrue( $result, 'delete_all_cached_data() should still return true.' );
-		$this->assertFalse( $fired, 'wp_cron() should NOT fire on a subsite.' );
+		$this->assertFalse( $spawn_attempted, 'wp_cron() should NOT attempt to spawn cron on a subsite.' );
 
 		wp_clear_scheduled_hook( 'gu_test_cron_action' );
+		remove_all_filters( 'cron_request' );
 		restore_current_blog();
 	}
 

--- a/tests/test-multisite-cron-guard.php
+++ b/tests/test-multisite-cron-guard.php
@@ -23,12 +23,12 @@ class Test_Multisite_Cron_Guard extends \WP_UnitTestCase {
 	use Fragen\Git_Updater\Traits\GU_Trait;
 
 	/**
-	 * Clean up cron events and filters after each test.
+	 * Clean up cron events and hooks after each test.
 	 */
 	public function tear_down() {
 		wp_clear_scheduled_hook( 'gu_delete_access_tokens' );
-		wp_clear_scheduled_hook( 'gu_test_cron_action' );
-		remove_all_filters( 'cron_request' );
+		remove_action( 'shutdown', '_wp_cron' );
+		remove_action( 'wp_loaded', '_wp_cron', 20 );
 		parent::tear_down();
 	}
 
@@ -41,45 +41,31 @@ class Test_Multisite_Cron_Guard extends \WP_UnitTestCase {
 	/**
 	 * On a single site, delete_all_cached_data() should call wp_cron().
 	 *
-	 * We verify by hooking into the 'cron_request' filter, which fires
-	 * inside spawn_cron() when wp_cron() reaches the point of spawning
-	 * the loopback request. In the test environment there is no HTTP
-	 * server, so we short-circuit the request and just record that the
-	 * code path was reached.
+	 * wp_cron() defers actual work to _wp_cron() via the 'shutdown' action
+	 * (or 'wp_loaded' when ALTERNATE_WP_CRON is set). We verify the guard
+	 * allowed wp_cron() to run by checking that _wp_cron was hooked.
 	 */
 	public function test_delete_all_cached_data_calls_wp_cron_on_single_site() {
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'Single-site test — skipped under multisite.' );
 		}
 
-		$spawn_attempted = false;
-		add_filter(
-			'cron_request',
-			function ( $cron_request ) use ( &$spawn_attempted ) {
-				$spawn_attempted = true;
-				// Return a blocking request with a very short timeout to
-				// prevent an actual HTTP call in the test environment.
-				$cron_request['args']['blocking'] = false;
-				$cron_request['args']['timeout']  = 0.01;
-				return $cron_request;
-			},
-			9999
-		);
-
-		// Schedule an event in the past so wp_cron() has something to process.
-		wp_schedule_single_event( time() - 1, 'gu_test_cron_action' );
-
-		// Clear the spawn-cron lock so wp_cron() doesn't bail early.
-		delete_transient( 'doing_cron' );
+		// Remove any pre-existing _wp_cron hook so we can detect a fresh add.
+		remove_action( 'shutdown', '_wp_cron' );
+		remove_action( 'wp_loaded', '_wp_cron', 20 );
 
 		$result = $this->delete_all_cached_data();
 
 		$this->assertTrue( $result, 'delete_all_cached_data() should return true.' );
-		$this->assertTrue( $spawn_attempted, 'wp_cron() should attempt to spawn cron on single-site.' );
+		$this->assertTrue(
+			has_action( 'shutdown', '_wp_cron' ) !== false
+			|| has_action( 'wp_loaded', '_wp_cron' ) !== false,
+			'wp_cron() should hook _wp_cron on single-site.'
+		);
 
 		// Clean up.
-		wp_clear_scheduled_hook( 'gu_test_cron_action' );
-		remove_all_filters( 'cron_request' );
+		remove_action( 'shutdown', '_wp_cron' );
+		remove_action( 'wp_loaded', '_wp_cron', 20 );
 	}
 
 	/**
@@ -96,28 +82,21 @@ class Test_Multisite_Cron_Guard extends \WP_UnitTestCase {
 		// Ensure we're on the main site.
 		switch_to_blog( get_main_site_id() );
 
-		$spawn_attempted = false;
-		add_filter(
-			'cron_request',
-			function ( $cron_request ) use ( &$spawn_attempted ) {
-				$spawn_attempted = true;
-				$cron_request['args']['blocking'] = false;
-				$cron_request['args']['timeout']  = 0.01;
-				return $cron_request;
-			},
-			9999
-		);
-
-		wp_schedule_single_event( time() - 1, 'gu_test_cron_action' );
-		delete_transient( 'doing_cron' );
+		// Remove any pre-existing _wp_cron hook so we can detect a fresh add.
+		remove_action( 'shutdown', '_wp_cron' );
+		remove_action( 'wp_loaded', '_wp_cron', 20 );
 
 		$result = $this->delete_all_cached_data();
 
 		$this->assertTrue( $result, 'delete_all_cached_data() should return true.' );
-		$this->assertTrue( $spawn_attempted, 'wp_cron() should attempt to spawn cron on the main site.' );
+		$this->assertTrue(
+			has_action( 'shutdown', '_wp_cron' ) !== false
+			|| has_action( 'wp_loaded', '_wp_cron' ) !== false,
+			'wp_cron() should hook _wp_cron on the main site.'
+		);
 
-		wp_clear_scheduled_hook( 'gu_test_cron_action' );
-		remove_all_filters( 'cron_request' );
+		remove_action( 'shutdown', '_wp_cron' );
+		remove_action( 'wp_loaded', '_wp_cron', 20 );
 		restore_current_blog();
 	}
 
@@ -138,28 +117,19 @@ class Test_Multisite_Cron_Guard extends \WP_UnitTestCase {
 
 		$this->assertFalse( is_main_site(), 'Should be on a subsite.' );
 
-		$spawn_attempted = false;
-		add_filter(
-			'cron_request',
-			function ( $cron_request ) use ( &$spawn_attempted ) {
-				$spawn_attempted = true;
-				$cron_request['args']['blocking'] = false;
-				$cron_request['args']['timeout']  = 0.01;
-				return $cron_request;
-			},
-			9999
-		);
-
-		wp_schedule_single_event( time() - 1, 'gu_test_cron_action' );
-		delete_transient( 'doing_cron' );
+		// Remove any pre-existing _wp_cron hook so we can detect a fresh add.
+		remove_action( 'shutdown', '_wp_cron' );
+		remove_action( 'wp_loaded', '_wp_cron', 20 );
 
 		$result = $this->delete_all_cached_data();
 
 		$this->assertTrue( $result, 'delete_all_cached_data() should still return true.' );
-		$this->assertFalse( $spawn_attempted, 'wp_cron() should NOT attempt to spawn cron on a subsite.' );
+		$this->assertFalse(
+			has_action( 'shutdown', '_wp_cron' ) !== false
+			|| has_action( 'wp_loaded', '_wp_cron' ) !== false,
+			'wp_cron() should NOT hook _wp_cron on a subsite.'
+		);
 
-		wp_clear_scheduled_hook( 'gu_test_cron_action' );
-		remove_all_filters( 'cron_request' );
 		restore_current_blog();
 	}
 


### PR DESCRIPTION
## Summary
- Restrict `gu_delete_access_tokens` cron scheduling to the main site when running in multisite.
- Prevent manual `wp_cron()` execution from running on subsites during cache cleanup.
- Kept single-site behavior unchanged.

This PR was prepared with AI assistance (aidevops.sh). All changes have been reviewed for correctness.

Closes #1137.

---
[aidevops.sh](https://aidevops.sh) v3.5.131 plugin for [OpenCode](https://opencode.ai) v1.3.3 with gpt-5.3-codex spent 2m and 45,674 tokens on this as a headless worker.