### PR TITLE
GH#866: add GitHub OAuth PKCE token flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ or
 
 ...where the above URI leads to the __owner/repository__ of your theme or plugin. The URI format is `https://github.com/<owner>/<repo>`. You **should not** include any extensions like `.git`.
 
+### GitHub OAuth Token Flow
+
+Git Updater can initiate a GitHub OAuth authorization flow from the GitHub settings tab and save the returned token as `github_access_token`.
+
+To enable OAuth, define credentials in `wp-config.php` (or provide them via the `gu_github_oauth_credentials` filter):
+
+```php
+define( 'GU_GITHUB_OAUTH_CLIENT_ID', 'your-client-id' );
+define( 'GU_GITHUB_OAUTH_CLIENT_SECRET', 'your-client-secret' ); // Optional when using PKCE-only app config.
+define( 'GU_GITHUB_OAUTH_SCOPE', 'repo' ); // Optional, defaults to repo.
+```
+
+After setting credentials, use **Authorize via GitHub OAuth** on the GitHub tab in Git Updater settings.
+
 ### API Plugins
 
 API plugins for Bitbucket, GitLab, Gitea, and Gist are available. API plugins are available for a one-click install from the **Add-Ons** tab.

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ or
 
 ...where the above URI leads to the __owner/repository__ of your theme or plugin. The URI format is `https://github.com/<owner>/<repo>`. You **should not** include any extensions like `.git`.
 
-### GitHub OAuth Token Flow
+### OAuth Token Flow
 
-Git Updater can initiate a GitHub OAuth authorization flow from the GitHub settings tab and save the returned token as `github_access_token`.
+Git Updater includes a reusable OAuth authorization-code + PKCE flow that API providers can use for host-specific OAuth apps. The bundled GitHub provider can initiate the flow from the GitHub settings tab and save the returned token as `github_access_token`.
 
 To enable OAuth, define credentials in `wp-config.php` (or provide them via the `gu_github_oauth_credentials` filter):
 
@@ -43,6 +43,8 @@ define( 'GU_GITHUB_OAUTH_SCOPE', 'repo' ); // Optional, defaults to repo.
 ```
 
 After setting credentials, use **Authorize via GitHub OAuth** on the GitHub tab in Git Updater settings.
+
+API add-ons can use `Fragen\Git_Updater\OAuth\OAuth_Flow` with provider-specific authorization/token endpoints, option names, constants, query args, and credential filters so Bitbucket, GitLab, Gitea, and Gist implementations share the same callback and PKCE handling.
 
 ### API Plugins
 

--- a/src/Git_Updater/API/GitHub_API.php
+++ b/src/Git_Updater/API/GitHub_API.php
@@ -39,6 +39,7 @@ class GitHub_API extends API implements API_Interface {
 		parent::__construct();
 		$this->type     = $type;
 		$this->response = [];
+		add_action( 'admin_init', [ $this, 'maybe_handle_oauth_flow' ] );
 		$this->settings_hook( $this );
 		$this->add_settings_subtab();
 		$this->add_install_fields( $this );
@@ -539,8 +540,301 @@ class GitHub_API extends API implements API_Interface {
 	 */
 	public function print_section_github_access_token() {
 		esc_html_e( 'Enter your personal GitHub.com or GitHub Enterprise Access Token to avoid API access limits.', 'git-updater' );
+		$this->render_oauth_controls();
 		$icon = plugin_dir_url( dirname( __DIR__, 2 ) ) . 'assets/github-logo.svg';
 		printf( '<img class="git-oauth-icon" src="%s" alt="GitHub logo" />', esc_attr( $icon ) );
+	}
+
+	/**
+	 * Output OAuth controls and status messages.
+	 */
+	private function render_oauth_controls() {
+		$credentials = $this->get_oauth_credentials();
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only status query arg for UI message only.
+		$status = isset( $_GET['gu_github_oauth'] ) ? sanitize_key( wp_unslash( $_GET['gu_github_oauth'] ) ) : '';
+
+		if ( 'success' === $status ) {
+			echo '<p><strong>' . esc_html__( 'OAuth token updated from GitHub.', 'git-updater' ) . '</strong></p>';
+		}
+
+		if ( str_starts_with( $status, 'error-' ) ) {
+			echo '<p><strong>' . esc_html__( 'GitHub OAuth was not completed. You can retry below.', 'git-updater' ) . '</strong></p>';
+		}
+
+		if ( empty( $credentials['client_id'] ) ) {
+			echo '<p>' . esc_html__( 'To enable OAuth login, set GU_GITHUB_OAUTH_CLIENT_ID in wp-config.php or filter gu_github_oauth_credentials.', 'git-updater' ) . '</p>';
+
+			return;
+		}
+
+		printf(
+			'<p><a class="button button-secondary" href="%s">%s</a></p>',
+			esc_url( $this->get_oauth_start_url() ),
+			esc_html__( 'Authorize via GitHub OAuth', 'git-updater' )
+		);
+	}
+
+	/**
+	 * Start OAuth flow and process callback.
+	 */
+	public function maybe_handle_oauth_flow() {
+		if ( ! is_admin() || ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is validated in start_oauth_flow().
+		if ( isset( $_GET['gu_github_oauth_start'] ) ) {
+			$this->start_oauth_flow();
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth state+PKCE verifier validation is used on callback.
+		if ( isset( $_GET['gu_github_oauth_callback'] ) ) {
+			$this->complete_oauth_flow();
+		}
+	}
+
+	/**
+	 * Build start URL for OAuth flow.
+	 *
+	 * @return string
+	 */
+	private function get_oauth_start_url() {
+		$redirect = $this->get_settings_redirect_url();
+
+		return add_query_arg(
+			[
+				'gu_github_oauth_start' => 1,
+				'_wpnonce'              => wp_create_nonce( 'gu-github-oauth-start' ),
+			],
+			$redirect
+		);
+	}
+
+	/**
+	 * Start GitHub OAuth redirect.
+	 */
+	private function start_oauth_flow() {
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ), 'gu-github-oauth-start' ) ) {
+			$this->oauth_redirect_with_status( 'error-nonce' );
+
+			return;
+		}
+
+		$credentials = $this->get_oauth_credentials();
+		if ( empty( $credentials['client_id'] ) ) {
+			$this->oauth_redirect_with_status( 'error-client-id' );
+
+			return;
+		}
+
+		$state    = wp_generate_password( 48, false, false );
+		$verifier = wp_generate_password( 96, false, false );
+		$key      = $this->get_oauth_transient_key( $state );
+
+		set_transient(
+			$key,
+			[
+				'code_verifier' => $verifier,
+			],
+			15 * MINUTE_IN_SECONDS
+		);
+
+		$authorize_url = add_query_arg(
+			[
+				'client_id'             => $credentials['client_id'],
+				'redirect_uri'          => $this->get_oauth_callback_url(),
+				'scope'                 => $credentials['scope'],
+				'state'                 => $state,
+				'code_challenge'        => $this->get_oauth_code_challenge( $verifier ),
+				'code_challenge_method' => 'S256',
+			],
+			'https://github.com/login/oauth/authorize'
+		);
+
+		wp_safe_redirect( $authorize_url );
+		exit;
+	}
+
+	/**
+	 * Process GitHub callback and save token.
+	 */
+	private function complete_oauth_flow() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth callback is validated through state and PKCE verifier.
+		$state = isset( $_GET['state'] ) ? sanitize_text_field( wp_unslash( $_GET['state'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth callback is validated through state and PKCE verifier.
+		$code = isset( $_GET['code'] ) ? sanitize_text_field( wp_unslash( $_GET['code'] ) ) : '';
+
+		if ( empty( $state ) || empty( $code ) ) {
+			$this->oauth_redirect_with_status( 'error-callback' );
+
+			return;
+		}
+
+		$key      = $this->get_oauth_transient_key( $state );
+		$flow     = get_transient( $key );
+		$verifier = is_array( $flow ) && ! empty( $flow['code_verifier'] ) ? $flow['code_verifier'] : '';
+		delete_transient( $key );
+
+		if ( empty( $verifier ) ) {
+			$this->oauth_redirect_with_status( 'error-state' );
+
+			return;
+		}
+
+		$credentials = $this->get_oauth_credentials();
+		$token       = $this->exchange_code_for_token( $credentials, $code, $verifier );
+
+		if ( empty( $token ) ) {
+			$this->oauth_redirect_with_status( 'error-token' );
+
+			return;
+		}
+
+		$options                        = get_site_option( 'git_updater', [] );
+		$options['github_access_token'] = $token;
+		update_site_option( 'git_updater', $options );
+		static::$options['github_access_token'] = $token;
+
+		$this->oauth_redirect_with_status( 'success' );
+	}
+
+	/**
+	 * Exchange callback code for access token.
+	 *
+	 * @param array  $credentials OAuth credentials.
+	 * @param string $code Callback code.
+	 * @param string $verifier PKCE verifier.
+	 *
+	 * @return string
+	 */
+	private function exchange_code_for_token( $credentials, $code, $verifier ) {
+		$body = [
+			'client_id'     => $credentials['client_id'],
+			'code'          => $code,
+			'redirect_uri'  => $this->get_oauth_callback_url(),
+			'code_verifier' => $verifier,
+		];
+
+		if ( ! empty( $credentials['client_secret'] ) ) {
+			$body['client_secret'] = $credentials['client_secret'];
+		}
+
+		$response = wp_remote_post(
+			'https://github.com/login/oauth/access_token',
+			[
+				'timeout' => 15,
+				'headers' => [
+					'Accept' => 'application/json',
+				],
+				'body'    => $body,
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return '';
+		}
+
+		$payload = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( ! is_array( $payload ) || empty( $payload['access_token'] ) ) {
+			return '';
+		}
+
+		return sanitize_text_field( $payload['access_token'] );
+	}
+
+	/**
+	 * Build callback URL for GitHub OAuth.
+	 *
+	 * @return string
+	 */
+	private function get_oauth_callback_url() {
+		return add_query_arg( 'gu_github_oauth_callback', 1, $this->get_settings_redirect_url() );
+	}
+
+	/**
+	 * Build redirect URL to GitHub subtab.
+	 *
+	 * @return string
+	 */
+	private function get_settings_redirect_url() {
+		$base = is_multisite() ? network_admin_url( 'settings.php' ) : admin_url( 'options-general.php' );
+
+		return add_query_arg(
+			[
+				'page'   => 'git-updater',
+				'tab'    => 'git_updater_settings',
+				'subtab' => 'github',
+			],
+			$base
+		);
+	}
+
+	/**
+	 * Redirect to GitHub settings with flow status.
+	 *
+	 * @param string $status OAuth status value.
+	 */
+	private function oauth_redirect_with_status( $status ) {
+		wp_safe_redirect(
+			add_query_arg(
+				'gu_github_oauth',
+				$status,
+				$this->get_settings_redirect_url()
+			)
+		);
+		exit;
+	}
+
+	/**
+	 * Return GitHub OAuth credentials.
+	 *
+	 * @return array
+	 */
+	private function get_oauth_credentials() {
+		$client_id     = defined( 'GU_GITHUB_OAUTH_CLIENT_ID' ) ? GU_GITHUB_OAUTH_CLIENT_ID : '';
+		$client_secret = defined( 'GU_GITHUB_OAUTH_CLIENT_SECRET' ) ? GU_GITHUB_OAUTH_CLIENT_SECRET : '';
+		$scope         = defined( 'GU_GITHUB_OAUTH_SCOPE' ) ? GU_GITHUB_OAUTH_SCOPE : 'repo';
+
+		$credentials = [
+			'client_id'     => $client_id,
+			'client_secret' => $client_secret,
+			'scope'         => $scope,
+		];
+
+		/**
+		 * Filter OAuth credentials for GitHub auth flow.
+		 *
+		 * @since 13.4.0
+		 *
+		 * @param array $credentials OAuth configuration.
+		 */
+		return apply_filters( 'gu_github_oauth_credentials', $credentials );
+	}
+
+	/**
+	 * Build transient key for OAuth flow state.
+	 *
+	 * @param string $state OAuth state.
+	 *
+	 * @return string
+	 */
+	private function get_oauth_transient_key( $state ) {
+		return 'gu_github_oauth_' . md5( $state );
+	}
+
+	/**
+	 * Build S256 PKCE challenge.
+	 *
+	 * @param string $verifier PKCE verifier.
+	 *
+	 * @return string
+	 */
+	private function get_oauth_code_challenge( $verifier ) {
+		$hash = hash( 'sha256', $verifier, true );
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Required for RFC7636 base64url PKCE encoding.
+		return rtrim( strtr( base64_encode( $hash ), '+/', '-_' ), '=' );
 	}
 
 	/**

--- a/src/Git_Updater/API/GitHub_API.php
+++ b/src/Git_Updater/API/GitHub_API.php
@@ -13,6 +13,7 @@
 namespace Fragen\Git_Updater\API;
 
 use Fragen\Singleton;
+use Fragen\Git_Updater\OAuth\OAuth_Flow;
 use stdClass;
 
 /*
@@ -549,9 +550,9 @@ class GitHub_API extends API implements API_Interface {
 	 * Output OAuth controls and status messages.
 	 */
 	private function render_oauth_controls() {
-		$credentials = $this->get_oauth_credentials();
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only status query arg for UI message only.
-		$status = isset( $_GET['gu_github_oauth'] ) ? sanitize_key( wp_unslash( $_GET['gu_github_oauth'] ) ) : '';
+		$oauth       = $this->get_oauth_flow();
+		$credentials = $oauth->get_credentials();
+		$status      = $oauth->get_status();
 
 		if ( 'success' === $status ) {
 			echo '<p><strong>' . esc_html__( 'OAuth token updated from GitHub.', 'git-updater' ) . '</strong></p>';
@@ -569,7 +570,7 @@ class GitHub_API extends API implements API_Interface {
 
 		printf(
 			'<p><a class="button button-secondary" href="%s">%s</a></p>',
-			esc_url( $this->get_oauth_start_url() ),
+			esc_url( $oauth->get_start_url() ),
 			esc_html__( 'Authorize via GitHub OAuth', 'git-updater' )
 		);
 	}
@@ -578,178 +579,34 @@ class GitHub_API extends API implements API_Interface {
 	 * Start OAuth flow and process callback.
 	 */
 	public function maybe_handle_oauth_flow() {
-		if ( ! is_admin() || ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is validated in start_oauth_flow().
-		if ( isset( $_GET['gu_github_oauth_start'] ) ) {
-			$this->start_oauth_flow();
-		}
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth state+PKCE verifier validation is used on callback.
-		if ( isset( $_GET['gu_github_oauth_callback'] ) ) {
-			$this->complete_oauth_flow();
-		}
+		$this->get_oauth_flow()->maybe_handle_flow();
 	}
 
 	/**
-	 * Build start URL for OAuth flow.
+	 * Build GitHub OAuth flow controller.
 	 *
-	 * @return string
+	 * @return OAuth_Flow
 	 */
-	private function get_oauth_start_url() {
-		$redirect = $this->get_settings_redirect_url();
-
-		return add_query_arg(
+	private function get_oauth_flow() {
+		return new OAuth_Flow(
 			[
-				'gu_github_oauth_start' => 1,
-				'_wpnonce'              => wp_create_nonce( 'gu-github-oauth-start' ),
-			],
-			$redirect
-		);
-	}
-
-	/**
-	 * Start GitHub OAuth redirect.
-	 */
-	private function start_oauth_flow() {
-		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ), 'gu-github-oauth-start' ) ) {
-			$this->oauth_redirect_with_status( 'error-nonce' );
-
-			return;
-		}
-
-		$credentials = $this->get_oauth_credentials();
-		if ( empty( $credentials['client_id'] ) ) {
-			$this->oauth_redirect_with_status( 'error-client-id' );
-
-			return;
-		}
-
-		$state    = wp_generate_password( 48, false, false );
-		$verifier = wp_generate_password( 96, false, false );
-		$key      = $this->get_oauth_transient_key( $state );
-
-		set_transient(
-			$key,
-			[
-				'code_verifier' => $verifier,
-			],
-			15 * MINUTE_IN_SECONDS
-		);
-
-		$authorize_url = add_query_arg(
-			[
-				'client_id'             => $credentials['client_id'],
-				'redirect_uri'          => $this->get_oauth_callback_url(),
-				'scope'                 => $credentials['scope'],
-				'state'                 => $state,
-				'code_challenge'        => $this->get_oauth_code_challenge( $verifier ),
-				'code_challenge_method' => 'S256',
-			],
-			'https://github.com/login/oauth/authorize'
-		);
-
-		wp_safe_redirect( $authorize_url );
-		exit;
-	}
-
-	/**
-	 * Process GitHub callback and save token.
-	 */
-	private function complete_oauth_flow() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth callback is validated through state and PKCE verifier.
-		$state = isset( $_GET['state'] ) ? sanitize_text_field( wp_unslash( $_GET['state'] ) ) : '';
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth callback is validated through state and PKCE verifier.
-		$code = isset( $_GET['code'] ) ? sanitize_text_field( wp_unslash( $_GET['code'] ) ) : '';
-
-		if ( empty( $state ) || empty( $code ) ) {
-			$this->oauth_redirect_with_status( 'error-callback' );
-
-			return;
-		}
-
-		$key      = $this->get_oauth_transient_key( $state );
-		$flow     = get_transient( $key );
-		$verifier = is_array( $flow ) && ! empty( $flow['code_verifier'] ) ? $flow['code_verifier'] : '';
-		delete_transient( $key );
-
-		if ( empty( $verifier ) ) {
-			$this->oauth_redirect_with_status( 'error-state' );
-
-			return;
-		}
-
-		$credentials = $this->get_oauth_credentials();
-		$token       = $this->exchange_code_for_token( $credentials, $code, $verifier );
-
-		if ( empty( $token ) ) {
-			$this->oauth_redirect_with_status( 'error-token' );
-
-			return;
-		}
-
-		$options                        = get_site_option( 'git_updater', [] );
-		$options['github_access_token'] = $token;
-		update_site_option( 'git_updater', $options );
-		static::$options['github_access_token'] = $token;
-
-		$this->oauth_redirect_with_status( 'success' );
-	}
-
-	/**
-	 * Exchange callback code for access token.
-	 *
-	 * @param array  $credentials OAuth credentials.
-	 * @param string $code Callback code.
-	 * @param string $verifier PKCE verifier.
-	 *
-	 * @return string
-	 */
-	private function exchange_code_for_token( $credentials, $code, $verifier ) {
-		$body = [
-			'client_id'     => $credentials['client_id'],
-			'code'          => $code,
-			'redirect_uri'  => $this->get_oauth_callback_url(),
-			'code_verifier' => $verifier,
-		];
-
-		if ( ! empty( $credentials['client_secret'] ) ) {
-			$body['client_secret'] = $credentials['client_secret'];
-		}
-
-		$response = wp_remote_post(
-			'https://github.com/login/oauth/access_token',
-			[
-				'timeout' => 15,
-				'headers' => [
-					'Accept' => 'application/json',
-				],
-				'body'    => $body,
+				'provider'               => 'github',
+				'label'                  => 'GitHub',
+				'option_name'            => 'github_access_token',
+				'settings_url'           => $this->get_settings_redirect_url(),
+				'authorize_url'          => 'https://github.com/login/oauth/authorize',
+				'token_url'              => 'https://github.com/login/oauth/access_token',
+				'default_scope'          => 'repo',
+				'credentials_filter'     => 'gu_github_oauth_credentials',
+				'client_id_constant'     => 'GU_GITHUB_OAUTH_CLIENT_ID',
+				'client_secret_constant' => 'GU_GITHUB_OAUTH_CLIENT_SECRET',
+				'scope_constant'         => 'GU_GITHUB_OAUTH_SCOPE',
+				'start_arg'              => 'gu_github_oauth_start',
+				'callback_arg'           => 'gu_github_oauth_callback',
+				'status_arg'             => 'gu_github_oauth',
+				'nonce_action'           => 'gu-github-oauth-start',
 			]
 		);
-
-		if ( is_wp_error( $response ) ) {
-			return '';
-		}
-
-		$payload = json_decode( wp_remote_retrieve_body( $response ), true );
-
-		if ( ! is_array( $payload ) || empty( $payload['access_token'] ) ) {
-			return '';
-		}
-
-		return sanitize_text_field( $payload['access_token'] );
-	}
-
-	/**
-	 * Build callback URL for GitHub OAuth.
-	 *
-	 * @return string
-	 */
-	private function get_oauth_callback_url() {
-		return add_query_arg( 'gu_github_oauth_callback', 1, $this->get_settings_redirect_url() );
 	}
 
 	/**
@@ -771,45 +628,12 @@ class GitHub_API extends API implements API_Interface {
 	}
 
 	/**
-	 * Redirect to GitHub settings with flow status.
-	 *
-	 * @param string $status OAuth status value.
-	 */
-	private function oauth_redirect_with_status( $status ) {
-		wp_safe_redirect(
-			add_query_arg(
-				'gu_github_oauth',
-				$status,
-				$this->get_settings_redirect_url()
-			)
-		);
-		exit;
-	}
-
-	/**
 	 * Return GitHub OAuth credentials.
 	 *
 	 * @return array
 	 */
 	private function get_oauth_credentials() {
-		$client_id     = defined( 'GU_GITHUB_OAUTH_CLIENT_ID' ) ? GU_GITHUB_OAUTH_CLIENT_ID : '';
-		$client_secret = defined( 'GU_GITHUB_OAUTH_CLIENT_SECRET' ) ? GU_GITHUB_OAUTH_CLIENT_SECRET : '';
-		$scope         = defined( 'GU_GITHUB_OAUTH_SCOPE' ) ? GU_GITHUB_OAUTH_SCOPE : 'repo';
-
-		$credentials = [
-			'client_id'     => $client_id,
-			'client_secret' => $client_secret,
-			'scope'         => $scope,
-		];
-
-		/**
-		 * Filter OAuth credentials for GitHub auth flow.
-		 *
-		 * @since 13.4.0
-		 *
-		 * @param array $credentials OAuth configuration.
-		 */
-		return apply_filters( 'gu_github_oauth_credentials', $credentials );
+		return $this->get_oauth_flow()->get_credentials();
 	}
 
 	/**
@@ -820,7 +644,7 @@ class GitHub_API extends API implements API_Interface {
 	 * @return string
 	 */
 	private function get_oauth_transient_key( $state ) {
-		return 'gu_github_oauth_' . md5( $state );
+		return $this->get_oauth_flow()->get_transient_key( $state );
 	}
 
 	/**
@@ -831,10 +655,7 @@ class GitHub_API extends API implements API_Interface {
 	 * @return string
 	 */
 	private function get_oauth_code_challenge( $verifier ) {
-		$hash = hash( 'sha256', $verifier, true );
-
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Required for RFC7636 base64url PKCE encoding.
-		return rtrim( strtr( base64_encode( $hash ), '+/', '-_' ), '=' );
+		return $this->get_oauth_flow()->get_code_challenge( $verifier );
 	}
 
 	/**

--- a/src/Git_Updater/OAuth/OAuth_Flow.php
+++ b/src/Git_Updater/OAuth/OAuth_Flow.php
@@ -1,0 +1,329 @@
+<?php
+/**
+ * Git Updater
+ *
+ * @author   Andy Fragen
+ * @license  GPL-3.0-or-later
+ * @link     https://github.com/afragen/git-updater
+ * @package  git-updater
+ */
+
+namespace Fragen\Git_Updater\OAuth;
+
+/*
+ * Exit if called directly.
+ */
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Reusable OAuth authorization-code + PKCE flow for Git Updater API providers.
+ *
+ * API add-ons can instantiate this class with provider-specific endpoints,
+ * option names, query args, constants, and filters instead of duplicating the
+ * callback, state, PKCE, token exchange, and settings redirect handling.
+ */
+class OAuth_Flow {
+	/**
+	 * OAuth provider configuration.
+	 *
+	 * @var array
+	 */
+	private $config;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $config OAuth provider configuration.
+	 */
+	public function __construct( $config ) {
+		$this->config = wp_parse_args(
+			$config,
+			[
+				'provider'               => '',
+				'label'                  => '',
+				'option_name'            => '',
+				'settings_url'           => '',
+				'authorize_url'          => '',
+				'token_url'              => '',
+				'default_scope'          => '',
+				'credentials_filter'     => '',
+				'client_id_constant'     => '',
+				'client_secret_constant' => '',
+				'scope_constant'         => '',
+				'start_arg'              => '',
+				'callback_arg'           => '',
+				'status_arg'             => '',
+				'nonce_action'           => '',
+			]
+		);
+	}
+
+	/**
+	 * Start OAuth flow and process callback.
+	 */
+	public function maybe_handle_flow() {
+		if ( ! is_admin() || ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$start_arg    = $this->config['start_arg'];
+		$callback_arg = $this->config['callback_arg'];
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is validated in start_flow().
+		if ( ! empty( $start_arg ) && isset( $_GET[ $start_arg ] ) ) {
+			$this->start_flow();
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth callback is validated through state and PKCE verifier.
+		if ( ! empty( $callback_arg ) && isset( $_GET[ $callback_arg ] ) ) {
+			$this->complete_flow();
+		}
+	}
+
+	/**
+	 * Return current OAuth status query arg for settings UI messaging.
+	 *
+	 * @return string
+	 */
+	public function get_status() {
+		$status_arg = $this->config['status_arg'];
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only status query arg for UI message only.
+		return ! empty( $status_arg ) && isset( $_GET[ $status_arg ] ) ? sanitize_key( wp_unslash( $_GET[ $status_arg ] ) ) : '';
+	}
+
+	/**
+	 * Build start URL for OAuth flow.
+	 *
+	 * @return string
+	 */
+	public function get_start_url() {
+		return add_query_arg(
+			[
+				$this->config['start_arg'] => 1,
+				'_wpnonce'                 => wp_create_nonce( $this->config['nonce_action'] ),
+			],
+			$this->config['settings_url']
+		);
+	}
+
+	/**
+	 * Return OAuth credentials from constants and provider filter.
+	 *
+	 * @return array
+	 */
+	public function get_credentials() {
+		$client_id_constant     = $this->config['client_id_constant'];
+		$client_secret_constant = $this->config['client_secret_constant'];
+		$scope_constant         = $this->config['scope_constant'];
+
+		$credentials = [
+			'client_id'     => $client_id_constant && defined( $client_id_constant ) ? constant( $client_id_constant ) : '',
+			'client_secret' => $client_secret_constant && defined( $client_secret_constant ) ? constant( $client_secret_constant ) : '',
+			'scope'         => $scope_constant && defined( $scope_constant ) ? constant( $scope_constant ) : $this->config['default_scope'],
+		];
+
+		return ! empty( $this->config['credentials_filter'] ) ? apply_filters( $this->config['credentials_filter'], $credentials, $this->config ) : $credentials;
+	}
+
+	/**
+	 * Build transient key for OAuth flow state.
+	 *
+	 * @param string $state OAuth state.
+	 *
+	 * @return string
+	 */
+	public function get_transient_key( $state ) {
+		return 'gu_' . sanitize_key( $this->config['provider'] ) . '_oauth_' . md5( $state );
+	}
+
+	/**
+	 * Build S256 PKCE challenge.
+	 *
+	 * @param string $verifier PKCE verifier.
+	 *
+	 * @return string
+	 */
+	public function get_code_challenge( $verifier ) {
+		$hash = hash( 'sha256', $verifier, true );
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Required for RFC7636 base64url PKCE encoding.
+		return rtrim( strtr( base64_encode( $hash ), '+/', '-_' ), '=' );
+	}
+
+	/**
+	 * Start provider OAuth redirect.
+	 */
+	private function start_flow() {
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ), $this->config['nonce_action'] ) ) {
+			$this->redirect_with_status( 'error-nonce' );
+
+			return;
+		}
+
+		$credentials = $this->get_credentials();
+		if ( empty( $credentials['client_id'] ) ) {
+			$this->redirect_with_status( 'error-client-id' );
+
+			return;
+		}
+
+		$state    = wp_generate_password( 48, false, false );
+		$verifier = wp_generate_password( 96, false, false );
+
+		set_transient(
+			$this->get_transient_key( $state ),
+			[
+				'code_verifier' => $verifier,
+			],
+			15 * MINUTE_IN_SECONDS
+		);
+
+		$authorize_args = [
+			'client_id'             => $credentials['client_id'],
+			'redirect_uri'          => $this->get_callback_url(),
+			'scope'                 => $credentials['scope'],
+			'state'                 => $state,
+			'code_challenge'        => $this->get_code_challenge( $verifier ),
+			'code_challenge_method' => 'S256',
+		];
+
+		/**
+		 * Filter provider authorize URL args before redirect.
+		 *
+		 * @since 13.4.0
+		 *
+		 * @param array $authorize_args OAuth authorize query args.
+		 * @param array $credentials    OAuth credentials.
+		 * @param array $config         OAuth provider configuration.
+		 */
+		$authorize_args = apply_filters( 'gu_oauth_authorize_args', $authorize_args, $credentials, $this->config );
+
+		wp_safe_redirect( add_query_arg( $authorize_args, $this->config['authorize_url'] ) );
+		exit;
+	}
+
+	/**
+	 * Process provider callback and save token.
+	 */
+	private function complete_flow() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth callback is validated through state and PKCE verifier.
+		$state = isset( $_GET['state'] ) ? sanitize_text_field( wp_unslash( $_GET['state'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth callback is validated through state and PKCE verifier.
+		$code = isset( $_GET['code'] ) ? sanitize_text_field( wp_unslash( $_GET['code'] ) ) : '';
+
+		if ( empty( $state ) || empty( $code ) ) {
+			$this->redirect_with_status( 'error-callback' );
+
+			return;
+		}
+
+		$key      = $this->get_transient_key( $state );
+		$flow     = get_transient( $key );
+		$verifier = is_array( $flow ) && ! empty( $flow['code_verifier'] ) ? $flow['code_verifier'] : '';
+		delete_transient( $key );
+
+		if ( empty( $verifier ) ) {
+			$this->redirect_with_status( 'error-state' );
+
+			return;
+		}
+
+		$token = $this->exchange_code_for_token( $this->get_credentials(), $code, $verifier );
+
+		if ( empty( $token ) ) {
+			$this->redirect_with_status( 'error-token' );
+
+			return;
+		}
+
+		$options                                 = get_site_option( 'git_updater', [] );
+		$options[ $this->config['option_name'] ] = $token;
+		update_site_option( 'git_updater', $options );
+
+		$this->redirect_with_status( 'success' );
+	}
+
+	/**
+	 * Exchange callback code for access token.
+	 *
+	 * @param array  $credentials OAuth credentials.
+	 * @param string $code Callback code.
+	 * @param string $verifier PKCE verifier.
+	 *
+	 * @return string
+	 */
+	private function exchange_code_for_token( $credentials, $code, $verifier ) {
+		$body = [
+			'client_id'     => $credentials['client_id'],
+			'code'          => $code,
+			'redirect_uri'  => $this->get_callback_url(),
+			'code_verifier' => $verifier,
+		];
+
+		if ( ! empty( $credentials['client_secret'] ) ) {
+			$body['client_secret'] = $credentials['client_secret'];
+		}
+
+		/**
+		 * Filter provider token request body before exchange.
+		 *
+		 * @since 13.4.0
+		 *
+		 * @param array $body        OAuth token request body.
+		 * @param array $credentials OAuth credentials.
+		 * @param array $config      OAuth provider configuration.
+		 */
+		$body = apply_filters( 'gu_oauth_token_request_body', $body, $credentials, $this->config );
+
+		$response = wp_remote_post(
+			$this->config['token_url'],
+			[
+				'timeout' => 15,
+				'headers' => [
+					'Accept' => 'application/json',
+				],
+				'body'    => $body,
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return '';
+		}
+
+		$payload = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( ! is_array( $payload ) || empty( $payload['access_token'] ) ) {
+			return '';
+		}
+
+		return sanitize_text_field( $payload['access_token'] );
+	}
+
+	/**
+	 * Build callback URL for provider OAuth.
+	 *
+	 * @return string
+	 */
+	private function get_callback_url() {
+		return add_query_arg( $this->config['callback_arg'], 1, $this->config['settings_url'] );
+	}
+
+	/**
+	 * Redirect to provider settings with flow status.
+	 *
+	 * @param string $status OAuth status value.
+	 */
+	private function redirect_with_status( $status ) {
+		wp_safe_redirect(
+			add_query_arg(
+				$this->config['status_arg'],
+				$status,
+				$this->config['settings_url']
+			)
+		);
+		exit;
+	}
+}

--- a/tests/test-github-oauth.php
+++ b/tests/test-github-oauth.php
@@ -1,11 +1,30 @@
 <?php
 
 use Fragen\Git_Updater\API\GitHub_API;
+use Fragen\Git_Updater\OAuth\OAuth_Flow;
 
 /**
  * Test GitHub OAuth helpers.
  */
 class Test_GitHub_OAuth extends \WP_UnitTestCase {
+
+	/**
+	 * Build a reusable OAuth flow instance for helper method tests.
+	 *
+	 * @return OAuth_Flow
+	 */
+	private function get_oauth_flow() {
+		return new OAuth_Flow(
+			[
+				'provider'     => 'github',
+				'option_name'  => 'github_access_token',
+				'settings_url' => admin_url( 'options-general.php?page=git-updater&tab=git_updater_settings&subtab=github' ),
+				'start_arg'    => 'gu_github_oauth_start',
+				'callback_arg' => 'gu_github_oauth_callback',
+				'status_arg'   => 'gu_github_oauth',
+			]
+		);
+	}
 
 	/**
 	 * Build an API instance for helper method tests.
@@ -36,8 +55,8 @@ class Test_GitHub_OAuth extends \WP_UnitTestCase {
 	 * Verify PKCE S256 challenge output.
 	 */
 	public function test_get_oauth_code_challenge() {
-		$api       = $this->get_api();
-		$challenge = $this->invoke_private_method( $api, 'get_oauth_code_challenge', [ 'abc123' ] );
+		$flow      = $this->get_oauth_flow();
+		$challenge = $flow->get_code_challenge( 'abc123' );
 
 		$this->assertSame( 'bKE9UspwyIPg8LsQHkJaiehiTeUdstI5JZOvaoQRgJA', $challenge );
 	}
@@ -46,9 +65,21 @@ class Test_GitHub_OAuth extends \WP_UnitTestCase {
 	 * Verify transient key derivation from OAuth state.
 	 */
 	public function test_get_oauth_transient_key() {
-		$api = $this->get_api();
-		$key = $this->invoke_private_method( $api, 'get_oauth_transient_key', [ 'state-value' ] );
+		$flow = $this->get_oauth_flow();
+		$key  = $flow->get_transient_key( 'state-value' );
 
+		$this->assertSame( 'gu_github_oauth_' . md5( 'state-value' ), $key );
+	}
+
+	/**
+	 * Verify GitHub API wrappers continue to use reusable OAuth helpers.
+	 */
+	public function test_github_api_oauth_helper_wrappers() {
+		$api       = $this->get_api();
+		$challenge = $this->invoke_private_method( $api, 'get_oauth_code_challenge', [ 'abc123' ] );
+		$key       = $this->invoke_private_method( $api, 'get_oauth_transient_key', [ 'state-value' ] );
+
+		$this->assertSame( 'bKE9UspwyIPg8LsQHkJaiehiTeUdstI5JZOvaoQRgJA', $challenge );
 		$this->assertSame( 'gu_github_oauth_' . md5( 'state-value' ), $key );
 	}
 }

--- a/tests/test-github-oauth.php
+++ b/tests/test-github-oauth.php
@@ -1,0 +1,54 @@
+<?php
+
+use Fragen\Git_Updater\API\GitHub_API;
+
+/**
+ * Test GitHub OAuth helpers.
+ */
+class Test_GitHub_OAuth extends \WP_UnitTestCase {
+
+	/**
+	 * Build an API instance for helper method tests.
+	 *
+	 * @return GitHub_API
+	 */
+	private function get_api() {
+		return new GitHub_API();
+	}
+
+	/**
+	 * Read private helper method values through reflection.
+	 *
+	 * @param GitHub_API $api API instance.
+	 * @param string     $method Private method name.
+	 * @param array      $args Method args.
+	 *
+	 * @return mixed
+	 */
+	private function invoke_private_method( $api, $method, $args = [] ) {
+		$reflection = new ReflectionMethod( $api, $method );
+		$reflection->setAccessible( true );
+
+		return $reflection->invokeArgs( $api, $args );
+	}
+
+	/**
+	 * Verify PKCE S256 challenge output.
+	 */
+	public function test_get_oauth_code_challenge() {
+		$api       = $this->get_api();
+		$challenge = $this->invoke_private_method( $api, 'get_oauth_code_challenge', [ 'abc123' ] );
+
+		$this->assertSame( 'bKE9UspwyIPg8LsQHkJaiehiTeUdstI5JZOvaoQRgJA', $challenge );
+	}
+
+	/**
+	 * Verify transient key derivation from OAuth state.
+	 */
+	public function test_get_oauth_transient_key() {
+		$api = $this->get_api();
+		$key = $this->invoke_private_method( $api, 'get_oauth_transient_key', [ 'state-value' ] );
+
+		$this->assertSame( 'gu_github_oauth_' . md5( 'state-value' ), $key );
+	}
+}


### PR DESCRIPTION
## Summary
- Add a reusable `Fragen\Git_Updater\OAuth\OAuth_Flow` authorization-code + PKCE flow for Git Updater API providers so host add-ons can share callback, state, token exchange, and settings redirect handling.
- Wire the bundled GitHub settings tab through the reusable OAuth flow while preserving `github_access_token`, `GU_GITHUB_OAUTH_*` constants, and the `gu_github_oauth_credentials` filter.
- Add focused helper tests for the reusable flow and GitHub wrappers, and document how API add-ons can provide provider-specific endpoints/configuration.

## Testing
- `php -l src/Git_Updater/OAuth/OAuth_Flow.php && php -l src/Git_Updater/API/GitHub_API.php && php -l tests/test-github-oauth.php`
- `./vendor/bin/phpcs --runtime-set installed_paths "vendor/wp-coding-standards/wpcs,vendor/phpcsstandards/phpcsextra,vendor/phpcsstandards/phpcsutils" src/Git_Updater/OAuth/OAuth_Flow.php tests/test-github-oauth.php`
- `phpunit --filter Test_GitHub_OAuth` was attempted but `phpunit` is not available in this worker environment.

## Runtime Testing
- Level: self-assessed (runtime environment for end-to-end OAuth callback not available in this session)
- Required manual verification: configure a provider OAuth app with the settings callback URL, use **Authorize via GitHub OAuth**, complete callback, and confirm `github_access_token` is saved.

## AI Disclosure
- This FOSS contribution was prepared with AI assistance.

Closes #866