### PR TITLE
Add 'Generate token' link to GitHub access token settings field

### DIFF
--- a/src/Git_Updater/API/GitHub_API.php
+++ b/src/Git_Updater/API/GitHub_API.php
@@ -493,8 +493,9 @@ class GitHub_API extends API implements API_Interface {
 			'git_updater_github_install_settings',
 			'github_access_token',
 			[
-				'id'    => 'github_access_token',
-				'token' => true,
+				'id'        => 'github_access_token',
+				'token'     => true,
+				'token_url' => 'https://github.com/settings/tokens/new',
 			]
 		);
 

--- a/src/Git_Updater/Settings.php
+++ b/src/Git_Updater/Settings.php
@@ -609,6 +609,9 @@ class Settings {
 		?>
 		<label for="<?php esc_attr( $args['id'] ); ?>">
 			<input class="gu-callback-text" type="<?php echo esc_attr( $type ); ?>" id="<?php esc_attr( $args['id'] ); ?>" name="git_updater[<?php echo esc_attr( $args['id'] ); ?>]" value="<?php echo esc_attr( $name ); ?>" placeholder="<?php echo esc_attr( $placeholder ); ?>">
+			<?php if ( ! empty( $args['token_url'] ) ) : ?>
+				&nbsp;<a href="<?php echo esc_url( $args['token_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Generate token', 'git-updater' ); ?></a>
+			<?php endif; ?>
 		</label>
 		<?php
 	}


### PR DESCRIPTION
## Summary

Adds a direct **Generate token** link next to the GitHub access token input field in the Settings page, so users can navigate to GitHub's token creation page without leaving the settings UI.

Closes #1024

## What changed

**`src/Git_Updater/API/GitHub_API.php`**  
Added `token_url` to the `add_settings_field` args for `github_access_token`:

```php
'token_url' => 'https://github.com/settings/tokens/new',
```

**`src/Git_Updater/Settings.php`**  
Modified `token_callback_text()` to conditionally render the link when `token_url` is present in `$args`:

```php
<?php if ( ! empty( $args['token_url'] ) ) : ?>
    &nbsp;<a href="<?php echo esc_url( $args['token_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Generate token', 'git-updater' ); ?></a>
<?php endif; ?>
```

## Design notes

- The `token_url` arg is optional — all existing callers of `token_callback_text()` that don't pass it are unaffected.
- This pattern is intentionally extensible: add-on plugins (git-updater-gitlab, git-updater-bitbucket) can pass their own `token_url` to get the same link behaviour without any further changes to core.
- Uses standard WordPress escaping (`esc_url`, `esc_html_e`) and `rel="noopener noreferrer"` for the external link.

## Verification

On the **Settings → Git Updater → GitHub** subtab, the GitHub.com Access Token field now shows a "Generate token" link to the right of the password input. The link opens `https://github.com/settings/tokens/new` in a new tab.

---

> **AI disclosure:** This contribution was drafted with the assistance of an AI coding tool (Claude). The implementation and diff were reviewed by the contributor before submission.