### PR TITLE
GH#866: harden OAuth connector callback

### DIFF
--- a/src/Git_Updater/OAuth/OAuth_Connect.php
+++ b/src/Git_Updater/OAuth/OAuth_Connect.php
@@ -83,7 +83,7 @@ class OAuth_Connect {
 		$connector = $this->get_connector_url();
 
 		if ( $token ) {
-			$this->render_connected_state( $provider, $config );
+			$this->render_connected_state( $provider );
 			return;
 		}
 
@@ -98,11 +98,10 @@ class OAuth_Connect {
 	/**
 	 * Render the connected state with disconnect button.
 	 *
-	 * @param string                $provider Provider slug.
-	 * @param array<string, string> $config   Provider configuration.
+	 * @param string $provider Provider slug.
 	 * @return void
 	 */
-	private function render_connected_state( string $provider, array $config ): void {
+	private function render_connected_state( string $provider ): void {
 		$disconnect_url = add_query_arg(
 			[
 				'action'   => 'gu_oauth_disconnect',
@@ -136,12 +135,19 @@ class OAuth_Connect {
 	 */
 	private function render_connect_button( string $provider, array $config, string $connector ): void {
 		$callback_url = $this->get_callback_url( $provider );
+		$state        = wp_create_nonce( 'gu_oauth_connect_' . $provider );
 
-		// Build the authorize URL on the connector
+		// Build the authorize URL on the connector.
 		$authorize_url = $connector . 'git-updater/' . $provider . '/oauth/authorize';
-		$authorize_url = add_query_arg( 'redirect', rawurlencode( $callback_url ), $authorize_url );
+		$authorize_url = add_query_arg(
+			[
+				'redirect' => rawurlencode( $callback_url ),
+				'state'    => $state,
+			],
+			$authorize_url
+		);
 
-		// Add Gitea-specific parameters if needed
+		// Add Gitea-specific parameters if needed.
 		if ( 'gitea' === $provider ) {
 			$options = get_site_option( 'git_updater', [] );
 			if ( ! empty( $options['gitea_server'] ) && ! empty( $options['gitea_client_id'] ) ) {
@@ -156,6 +162,7 @@ class OAuth_Connect {
 		}
 
 		echo '<a href="' . esc_url( $authorize_url ) . '" class="button button-primary">';
+		/* translators: %s: Git provider name. */
 		echo esc_html( sprintf( __( 'Connect %s', 'git-updater' ), $config['label'] ) );
 		echo '</a>';
 	}
@@ -172,8 +179,13 @@ class OAuth_Connect {
 
 		$provider      = sanitize_key( $_GET['provider'] ?? '' );
 		$exchange_code = sanitize_text_field( wp_unslash( $_GET['gu_exchange_code'] ?? '' ) );
+		$state         = sanitize_text_field( wp_unslash( $_GET['state'] ?? '' ) );
 
-		if ( ! isset( self::PROVIDERS[ $provider ] ) || empty( $exchange_code ) ) {
+		if (
+			! isset( self::PROVIDERS[ $provider ] )
+			|| empty( $exchange_code )
+			|| ! wp_verify_nonce( $state, 'gu_oauth_connect_' . $provider )
+		) {
 			$this->redirect_with_status( $provider, 'oauth_error' );
 			return; // @codeCoverageIgnore
 		}
@@ -257,10 +269,20 @@ class OAuth_Connect {
 		}
 
 		$url = $connector . 'git-updater/' . $provider . '/oauth/token';
-		$url = add_query_arg( 'code', $exchange_code, $url );
 
-		$response = wp_remote_get( $url, [ 'timeout' => 15 ] );
+		$response = wp_remote_post(
+			$url,
+			[
+				'timeout' => 15,
+				'body'    => [ 'code' => $exchange_code ],
+			]
+		);
 		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( $response_code < 200 || $response_code >= 300 ) {
 			return null;
 		}
 
@@ -355,6 +377,11 @@ class OAuth_Connect {
 		);
 
 		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( $response_code < 200 || $response_code >= 300 ) {
 			return null;
 		}
 

--- a/tests/test-oauth-connect.php
+++ b/tests/test-oauth-connect.php
@@ -26,7 +26,7 @@ class Test_OAuth_Connect extends GU_Test_Case {
 		parent::set_up();
 		$this->oauth = new OAuth_Connect();
 		delete_site_option( 'git_updater' );
-		unset( $_GET['provider'], $_GET['gu_exchange_code'], $_GET['_wpnonce'], $_POST['provider'], $_POST['_wpnonce'] );
+		unset( $_GET['provider'], $_GET['gu_exchange_code'], $_GET['state'], $_GET['_wpnonce'], $_POST['provider'], $_POST['_wpnonce'] );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'wp_redirect' );
 	}
@@ -36,7 +36,7 @@ class Test_OAuth_Connect extends GU_Test_Case {
 	 */
 	public function tear_down(): void {
 		delete_site_option( 'git_updater' );
-		unset( $_GET['provider'], $_GET['gu_exchange_code'], $_GET['_wpnonce'], $_POST['provider'], $_POST['_wpnonce'] );
+		unset( $_GET['provider'], $_GET['gu_exchange_code'], $_GET['state'], $_GET['_wpnonce'], $_POST['provider'], $_POST['_wpnonce'] );
 		remove_all_actions( 'admin_post_gu_oauth_callback' );
 		remove_all_actions( 'admin_post_gu_oauth_disconnect' );
 		remove_all_filters( 'pre_http_request' );
@@ -161,6 +161,7 @@ class Test_OAuth_Connect extends GU_Test_Case {
 		$this->assertStringContainsString( 'Connect GitHub', $output );
 		$this->assertStringContainsString( 'button-primary', $output );
 		$this->assertStringContainsString( 'gu_oauth_callback', $output );
+		$this->assertStringContainsString( 'state=', $output );
 	}
 
 	/**
@@ -244,9 +245,12 @@ class Test_OAuth_Connect extends GU_Test_Case {
 
 		$_GET['provider']         = 'github';
 		$_GET['gu_exchange_code'] = 'test_exchange_code';
+		$_GET['state']            = wp_create_nonce( 'gu_oauth_connect_github' );
 
 		add_filter( 'pre_http_request', static function( $preempt, $args, $url ) {
 			if ( strpos( $url, '/token' ) !== false ) {
+				self::assertSame( 'POST', $args['method'] );
+				self::assertSame( 'test_exchange_code', $args['body']['code'] );
 				return [
 					'response' => [ 'code' => 200, 'message' => 'OK' ],
 					'body'     => wp_json_encode( [ 'access_token' => 'test_access_token' ] ),
@@ -288,6 +292,7 @@ class Test_OAuth_Connect extends GU_Test_Case {
 
 		$_GET['provider']         = 'github';
 		$_GET['gu_exchange_code'] = 'test_exchange_code';
+		$_GET['state']            = wp_create_nonce( 'gu_oauth_connect_github' );
 
 		add_filter( 'pre_http_request', static function( $preempt, $args, $url ) {
 			if ( strpos( $url, '/token' ) !== false ) {
@@ -295,6 +300,35 @@ class Test_OAuth_Connect extends GU_Test_Case {
 			}
 			return $preempt;
 		}, 10, 3 );
+
+		$captured_url = null;
+		add_filter( 'wp_redirect', function( $url ) use ( &$captured_url ) {
+			$captured_url = $url;
+			throw new RuntimeException( 'Redirect captured' );
+		} );
+
+		try {
+			$this->oauth->handle_callback();
+			$this->fail( 'Expected redirect to be captured' );
+		} catch ( RuntimeException $e ) {
+			$this->assertStringContainsString( 'Redirect captured', $e->getMessage() );
+		}
+
+		$this->assertNotNull( $captured_url );
+		$this->assertStringContainsString( 'oauth_error', $captured_url );
+	}
+
+	/**
+	 * Test handle_callback rejects an invalid state value.
+	 */
+	public function test_handle_callback_with_invalid_state(): void {
+		$user = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$this->maybe_grant_super_admin( $user );
+		wp_set_current_user( $user );
+
+		$_GET['provider']         = 'github';
+		$_GET['gu_exchange_code'] = 'test_exchange_code';
+		$_GET['state']            = 'invalid_state';
 
 		$captured_url = null;
 		add_filter( 'wp_redirect', function( $url ) use ( &$captured_url ) {
@@ -393,6 +427,7 @@ class Test_OAuth_Connect extends GU_Test_Case {
 
 		$_GET['provider']         = 'github';
 		$_GET['gu_exchange_code'] = 'github_code';
+		$_GET['state']            = wp_create_nonce( 'gu_oauth_connect_github' );
 		add_filter( 'pre_http_request', static function( $preempt, $args, $url ) {
 			if ( strpos( $url, 'github' ) !== false && strpos( $url, '/token' ) !== false ) {
 				return [
@@ -424,6 +459,7 @@ class Test_OAuth_Connect extends GU_Test_Case {
 
 		$_GET['provider']         = 'gitlab';
 		$_GET['gu_exchange_code'] = 'gitlab_code';
+		$_GET['state']            = wp_create_nonce( 'gu_oauth_connect_gitlab' );
 
 		try {
 			$this->oauth->handle_callback();
@@ -446,6 +482,7 @@ class Test_OAuth_Connect extends GU_Test_Case {
 
 		$_GET['provider'] = 'invalid_provider';
 		$_GET['gu_exchange_code'] = 'test_code';
+		$_GET['state'] = wp_create_nonce( 'gu_oauth_connect_invalid_provider' );
 
 		$captured_url = null;
 		add_filter( 'wp_redirect', function( $url ) use ( &$captured_url ) {
@@ -474,6 +511,7 @@ class Test_OAuth_Connect extends GU_Test_Case {
 
 		$_GET['provider'] = 'github';
 		$_GET['gu_exchange_code'] = '';
+		$_GET['state'] = wp_create_nonce( 'gu_oauth_connect_github' );
 
 		$captured_url = null;
 		add_filter( 'wp_redirect', function( $url ) use ( &$captured_url ) {
@@ -621,6 +659,21 @@ class Test_OAuth_Connect extends GU_Test_Case {
 		$this->assertNull( $this->oauth->refresh_token( 'gitlab' ) );
 	}
 
+	public function test_refresh_token_returns_null_on_failed_http_status(): void {
+		$this->oauth->connector_url = 'https://connector.example.com/';
+		update_site_option( 'git_updater', [ 'gitlab_access_token' => 'tok', 'gitlab_refresh_token' => 'ref' ] );
+
+		add_filter( 'pre_http_request', static function () {
+			return [
+				'response' => [ 'code' => 500 ],
+				'body'     => wp_json_encode( [ 'access_token' => 'tok' ] ),
+				'headers'  => [],
+			];
+		}, 10, 3 );
+
+		$this->assertNull( $this->oauth->refresh_token( 'gitlab' ) );
+	}
+
 	public function test_refresh_token_returns_new_token_on_success(): void {
 		$this->oauth->connector_url = 'https://connector.example.com/';
 		update_site_option( 'git_updater', [ 'gitlab_access_token' => 'old_tok', 'gitlab_refresh_token' => 'ref' ] );
@@ -673,7 +726,10 @@ class Test_OAuth_Connect extends GU_Test_Case {
 	public function test_fetch_token_returns_array_with_access_token_only(): void {
 		$this->oauth->connector_url = 'https://connector.example.com/';
 
-		add_filter( 'pre_http_request', static function () {
+		add_filter( 'pre_http_request', static function ( $preempt, $args ) {
+			self::assertSame( 'POST', $args['method'] );
+			self::assertSame( 'code', $args['body']['code'] );
+
 			return [
 				'response' => [ 'code' => 200 ],
 				'body'     => wp_json_encode( [ 'access_token' => 'tok' ] ),
@@ -690,6 +746,25 @@ class Test_OAuth_Connect extends GU_Test_Case {
 		$this->assertSame( 'tok', $result['access_token'] );
 		$this->assertNull( $result['refresh_token'] );
 		$this->assertNull( $result['expires_in'] );
+	}
+
+	public function test_fetch_token_returns_null_on_failed_http_status(): void {
+		$this->oauth->connector_url = 'https://connector.example.com/';
+
+		add_filter( 'pre_http_request', static function () {
+			return [
+				'response' => [ 'code' => 400 ],
+				'body'     => wp_json_encode( [ 'access_token' => 'tok' ] ),
+				'headers'  => [],
+			];
+		}, 10, 3 );
+
+		$method = new ReflectionMethod( OAuth_Connect::class, 'fetch_token_from_connector' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->oauth, 'github', 'code' );
+
+		$this->assertNull( $result );
 	}
 
 	public function test_fetch_token_returns_array_with_all_fields(): void {
@@ -807,6 +882,7 @@ class Test_OAuth_Connect extends GU_Test_Case {
 
 		$_GET['provider']         = 'gitlab';
 		$_GET['gu_exchange_code'] = 'test_exchange_code';
+		$_GET['state']            = wp_create_nonce( 'gu_oauth_connect_gitlab' );
 
 		add_filter( 'pre_http_request', static function ( $preempt, $args, $url ) {
 			if ( strpos( $url, '/token' ) !== false ) {


### PR DESCRIPTION
## Summary
- Add a state nonce to the OAuth connector authorize URL and validate it on callback before accepting an exchange code.
- Exchange connector authorization codes with `POST` instead of a query-string `GET`.
- Require successful 2xx connector responses before accepting access or refresh token payloads.
- Add focused OAuth connector tests for state handling, POST exchange, and failed HTTP statuses.

## Testing
- `php -l src/Git_Updater/OAuth/OAuth_Connect.php && php -l tests/test-oauth-connect.php`
- `./vendor/bin/phpcs src/Git_Updater/OAuth/OAuth_Connect.php tests/test-oauth-connect.php`
- `composer phpstan`

## Notes
- `composer lint` still reports existing warnings elsewhere on the current `oauth` branch (`Install.php`, `Repo_List_Table.php`, `API.php`, and `GitHub_API.php`), but no errors remain in the changed OAuth files.
- `./vendor/bin/phpunit --config=phpunit.xml --filter Test_OAuth_Connect` could not run locally because the WordPress test library is not installed at `/var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/wordpress-tests-lib/includes/functions.php`.

Ref #866

## AI disclosure
This FOSS contribution was prepared with AI assistance.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 8m and 139,067 tokens on this with the user in an interactive session.
