### PR TITLE
fix: harden OAuth connector token exchange

### DIFF
--- a/src/Git_Updater/OAuth/OAuth_Connect.php
+++ b/src/Git_Updater/OAuth/OAuth_Connect.php
@@ -272,11 +272,20 @@ class OAuth_Connect {
 			return null;
 		}
 
-		$url = $connector . 'git-updater/' . $provider . '/oauth/token';
-		$url = add_query_arg( 'code', $exchange_code, $url );
-
-		$response = wp_remote_get( $url, [ 'timeout' => 15 ] );
+		$url      = $connector . 'git-updater/' . $provider . '/oauth/token';
+		$response = wp_remote_post(
+			$url,
+			[
+				'timeout' => 15,
+				'body'    => [ 'code' => $exchange_code ],
+			]
+		);
 		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( $response_code < 200 || $response_code >= 300 ) {
 			return null;
 		}
 
@@ -377,6 +386,11 @@ class OAuth_Connect {
 		);
 
 		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( $response_code < 200 || $response_code >= 300 ) {
 			return null;
 		}
 

--- a/src/Git_Updater/OAuth/OAuth_Connect.php
+++ b/src/Git_Updater/OAuth/OAuth_Connect.php
@@ -84,7 +84,7 @@ class OAuth_Connect {
 		$connector = $this->get_connector_url();
 
 		if ( $token ) {
-			$this->render_connected_state( $provider, $config );
+			$this->render_connected_state( $provider );
 			return;
 		}
 
@@ -99,11 +99,10 @@ class OAuth_Connect {
 	/**
 	 * Render the connected state with disconnect button.
 	 *
-	 * @param string                $provider Provider slug.
-	 * @param array<string, string> $config   Provider configuration.
+	 * @param string $provider Provider slug.
 	 * @return void
 	 */
-	private function render_connected_state( string $provider, array $config ): void {
+	private function render_connected_state( string $provider ): void {
 		$disconnect_url = add_query_arg(
 			[
 				'action'   => 'gu_oauth_disconnect',
@@ -177,9 +176,12 @@ class OAuth_Connect {
 			wp_die( esc_html__( 'Forbidden', 'git-updater' ) ); // @codeCoverageIgnore
 		}
 
-		$provider      = sanitize_key( $_GET['provider'] ?? '' );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth callback is validated by the single-use site_state below.
+		$provider = sanitize_key( $_GET['provider'] ?? '' );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth callback is validated by the single-use site_state below.
 		$exchange_code = sanitize_text_field( wp_unslash( $_GET['gu_exchange_code'] ?? '' ) );
-		$site_state    = sanitize_text_field( wp_unslash( $_GET['site_state'] ?? '' ) );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth callback is validated by the single-use site_state below.
+		$site_state = sanitize_text_field( wp_unslash( $_GET['site_state'] ?? '' ) );
 
 		if ( ! isset( self::PROVIDERS[ $provider ] ) || empty( $exchange_code ) ) {
 			$this->redirect_with_status( $provider, 'oauth_error' );

--- a/tests/test-oauth-connect.php
+++ b/tests/test-oauth-connect.php
@@ -674,6 +674,24 @@ class Test_OAuth_Connect extends GU_Test_Case {
 		$this->assertNull( $this->oauth->refresh_token( 'gitlab' ) );
 	}
 
+	public function test_refresh_token_returns_null_on_non_success_response(): void {
+		$this->oauth->connector_url = 'https://connector.example.com/';
+		update_site_option( 'git_updater', [ 'gitlab_access_token' => 'tok', 'gitlab_refresh_token' => 'ref' ] );
+
+		add_filter( 'pre_http_request', static function () {
+			return [
+				'response' => [ 'code' => 401 ],
+				'body'     => wp_json_encode( [ 'access_token' => 'should_not_save' ] ),
+				'headers'  => [],
+			];
+		}, 10, 3 );
+
+		$this->assertNull( $this->oauth->refresh_token( 'gitlab' ) );
+
+		$options = get_site_option( 'git_updater' );
+		$this->assertSame( 'tok', $options['gitlab_access_token'] );
+	}
+
 	public function test_refresh_token_returns_new_token_on_success(): void {
 		$this->oauth->connector_url = 'https://connector.example.com/';
 		update_site_option( 'git_updater', [ 'gitlab_access_token' => 'old_tok', 'gitlab_refresh_token' => 'ref' ] );
@@ -727,7 +745,14 @@ class Test_OAuth_Connect extends GU_Test_Case {
 	public function test_fetch_token_returns_array_with_access_token_only(): void {
 		$this->oauth->connector_url = 'https://connector.example.com/';
 
-		add_filter( 'pre_http_request', static function () {
+		add_filter( 'pre_http_request', static function ( $preempt, $args, $url ) {
+			if ( 'https://connector.example.com/git-updater/github/oauth/token' !== $url ) {
+				return $preempt;
+			}
+
+			Test_OAuth_Connect::assertSame( 'POST', $args['method'] );
+			Test_OAuth_Connect::assertSame( [ 'code' => 'code' ], $args['body'] );
+
 			return [
 				'response' => [ 'code' => 200 ],
 				'body'     => wp_json_encode( [ 'access_token' => 'tok' ] ),
@@ -744,6 +769,25 @@ class Test_OAuth_Connect extends GU_Test_Case {
 		$this->assertSame( 'tok', $result['access_token'] );
 		$this->assertNull( $result['refresh_token'] );
 		$this->assertNull( $result['expires_in'] );
+	}
+
+	public function test_fetch_token_returns_null_on_non_success_response(): void {
+		$this->oauth->connector_url = 'https://connector.example.com/';
+
+		add_filter( 'pre_http_request', static function () {
+			return [
+				'response' => [ 'code' => 500 ],
+				'body'     => wp_json_encode( [ 'access_token' => 'should_not_save' ] ),
+				'headers'  => [],
+			];
+		}, 10, 3 );
+
+		$method = new ReflectionMethod( OAuth_Connect::class, 'fetch_token_from_connector' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->oauth, 'github', 'code' );
+
+		$this->assertNull( $result );
 	}
 
 	public function test_fetch_token_returns_array_with_all_fields(): void {


### PR DESCRIPTION
## Summary
- Exchange connector `gu_exchange_code` values with the OAuth connector via `POST` instead of query-string `GET`.
- Reject non-2xx token and refresh responses before accepting `access_token` values from connector response bodies.
- Add focused regression coverage for non-success token/refresh responses and the token exchange request method/body.

For #866.

## Testing
- `php -l src/Git_Updater/OAuth/OAuth_Connect.php && php -l tests/test-oauth-connect.php`
- `php vendor/bin/phpcs src/Git_Updater/OAuth/OAuth_Connect.php tests/test-oauth-connect.php`
- `composer run phpstan -- --no-progress`

Attempted but blocked locally:
- `php vendor/bin/phpunit --filter Test_OAuth_Connect --colors=never` — local worker lacks `/tmp/wordpress-tests-lib/includes/functions.php`.
- `npm test -- --filter Test_OAuth_Connect` after `npm run wp-env start` — Docker credential helper failed in this headless session with `User canceled the operation. (-128)`.

## AI disclosure
This PR was prepared with AI assistance using aidevops/OpenCode; the code and verification results above were reviewed before submission.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5
