### PR TITLE
Create an autofill for URI and branch if an Oauth connection exists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,17 @@
 #### [unreleased]
+* add GitHub OAuth-powered autocomplete to the Install Plugin/Theme screen — repo URI field shows a live-filtered dropdown of all repositories (personal + organization) accessible via the connected OAuth account, with debounce, spinner, keyboard navigation (↑ ↓ Enter Esc), and ARIA attributes
+* add branch autocomplete to the Repository Branch field — once a connected-account repo URI is entered, typing in the branch field filters available branches fetched from the GitHub API
+* add branch autofill — when a connected-account repo is selected and its default branch is not `master`, the Repository Branch field is populated automatically
+* add field-hiding — when the entered URI belongs to the connected GitHub account (personal or org), the Remote Repository Host selector and GitHub Access Token field are hidden as they are not needed for OAuth-authenticated installs
+* add `Install::ajax_github_repos()` AJAX handler (`gu_github_repos`) — returns paginated, cached repo list for the connected account, searched by query string
+* add `Install::ajax_github_branches()` AJAX handler (`gu_github_branches`) — returns branch names for a given `owner/repo`, cached 5 minutes
+* add `Install::ajax_github_repo_info()` AJAX handler (`gu_github_repo_info`) — returns `default_branch` and owner for a given repo, cached 5 minutes
+* add `Install::fetch_all_github_repos()` — paginates `/user/repos` and all organization repos via `/user/orgs` + `/orgs/{org}/repos`, deduplicates by `full_name`, capped at 1 000 items
+* add `Install::github_paginate()` — shared paginator for GitHub API endpoints
+* add `Install::get_github_username()` — fetches and caches the authenticated user's login for 1 hour
+* add `Install::get_github_org_logins()` — fetches and caches the authenticated user's organization slugs for 1 hour, used by JS to recognize org repos as connected-account repos
+* add `Install::register_ajax_handlers()` — hooked from `Settings::load_hooks()` so AJAX actions are registered on all admin requests including `admin-ajax.php`
+* fix `Install` AJAX handlers were unreachable during `wp_doing_ajax()` because `Settings::page_init()` (which called `Install::run()`) was gated behind `! wp_doing_ajax()`; handlers are now registered in `Settings::load_hooks()` instead
 * fix `Rest_Update::update_plugin()` inverted activation check — `activate_plugin()` returns `null` on success and `WP_Error` on failure; old code `if ( ! $activate )` silently swallowed failures; now reports error message from `WP_Error`
 * fix `API::api()` missing `WP_Error` check after OAuth retry — retry response now validated like the initial request
 * fix `API::get_release_asset_redirect()` AWS cache age calculation to use `$this->hours` instead of hardcoded `-12 hours`

--- a/docs/claude-architecture.md
+++ b/docs/claude-architecture.md
@@ -94,6 +94,38 @@ Plugin/theme repo objects (`$this->type`) are `stdClass` instances populated wit
 
 All plugin options are stored in a single site option `git_updater` (an array). `GU_Upgrade` handles migration from legacy `github_updater` option names. Settings UI is in `Settings.php`; per-repo authentication fields are added via `gu_add_settings` and `gu_add_repo_setting_field` filters implemented in each API class.
 
+### Install screen GitHub OAuth autocomplete
+
+`Install.php` adds three `wp_ajax_*` AJAX handlers that power the autocomplete UX on the Install Plugin / Install Theme tab when a GitHub OAuth token is active.
+
+**AJAX registration** — `Install::register_ajax_handlers()` is called from `Settings::load_hooks()` (not from `Install::run()`) so the handlers are available on all admin requests, including `admin-ajax.php`. `Install::run()` is gated behind `! wp_doing_ajax()` in `Settings::page_init()`, so any hook registration inside `run()` would be invisible to AJAX requests.
+
+**`gu_github_repos`** — Accepts a `q` query param. Calls `fetch_all_github_repos()` which paginates `/user/repos` (type=all) and then paginates `/orgs/{org}/repos` for every org returned by `/user/orgs`. Results are deduplicated by `full_name` and cached in a site transient keyed by `md5($token)` for 5 minutes. The handler filters the cached list by `q` and returns up to 20 matches.
+
+**`gu_github_branches`** — Accepts a `repo` param (`owner/repo`). Paginates `/repos/{owner}/{repo}/branches` and caches the branch name list for 5 minutes.
+
+**`gu_github_repo_info`** — Accepts a `repo` param. Fetches `/repos/{owner}/{repo}` and returns `default_branch`, `private`, and `owner` login. Cached 5 minutes.
+
+**Script data** — `load_js()` localises `guInstallData` onto `gu-install` with:
+- `ajaxurl` — `admin-ajax.php` URL
+- `nonce` — `gu_github_install_autocomplete` nonce
+- `github_oauth` — `'1'` when a GitHub OAuth token is stored
+- `github_username` — authenticated user's login (from `/user`, cached 1 hour via `get_github_username()`)
+- `github_orgs` — lowercase array of org slugs the user belongs to (from `/user/orgs`, cached 1 hour via `get_github_org_logins()`), used to recognise org repos as "connected account" repos
+
+**JS behaviour** (`js/gu-install-vanilla.js`) — The autocomplete runs only when `github_oauth === '1'`. Both the URI and Branch fields get independent dropdowns with:
+- Debounced input (250 ms) with an immediate CSS spinner while waiting
+- Keyboard navigation: ↑/↓ moves highlight, Enter selects, Escape closes
+- ARIA: `role="combobox"` on inputs, `role="listbox"` on lists, `role="option"` on items, `aria-expanded`, `aria-activedescendant`
+- `li._guRepo` / `li._guBranch` properties store the data object for keyboard selection without re-parsing `dataset`
+
+When a URI from a connected account is entered or selected, `applyConnectedRepoState()`:
+1. Sets the host dropdown to `github` and dispatches a `change` event (to trigger existing show/hide logic for other API token fields)
+2. Calls `hideHostAndTokenFields()` **after** the dispatch — the change handler would otherwise re-show the `github_setting` rows
+3. Fetches and autofills the default branch if the field is empty or set to `master` and the actual default differs
+
+The "connected account" check compares the repo owner (extracted from full URL or `owner/repo` slug) against `github_username` and all entries in `github_orgs`.
+
 ### Coding standards
 
 PHPCS uses the `WordPress` ruleset with several exclusions defined in `phpcs.xml`. Notable: short array syntax (`[]`) is enforced, file naming and variable naming WordPress conventions are relaxed, and some Squiz control structure rules are disabled.

--- a/js/gu-install-vanilla.js
+++ b/js/gu-install-vanilla.js
@@ -1,6 +1,6 @@
 /**
  * Vanilla Javascript to show and hide the API specific settings
- * for the remote install feature.
+ * for the remote install feature, with GitHub OAuth autocomplete support.
  *
  * @class  Fragen\GitHub_Updater\Install
  * @since  8.5.0
@@ -80,11 +80,632 @@
 						display( parents );
 					}
 				);
-
-				console.log( 'selected', this.value );
-				console.log( 'hideMe', hideMe );
 			}
 		);
+	}
+
+	// -------------------------------------------------------------------------
+	// GitHub OAuth autocomplete for Plugin/Theme URI field
+	// -------------------------------------------------------------------------
+
+	var guData        = window.guInstallData || {};
+	var githubOauth   = guData.github_oauth === '1';
+	var githubUser    = guData.github_username || '';
+	var githubOrgs    = Array.isArray( guData.github_orgs ) ? guData.github_orgs.map( function (o) { return o.toLowerCase(); } ) : [];
+	var ajaxUrl       = guData.ajaxurl || '';
+	var ajaxNonce     = guData.nonce || '';
+
+	var repoInput  = document.getElementById( 'git_updater_repo' );
+	var branchInput = document.getElementById( 'git_updater_branch' );
+
+	if ( repoInput && githubOauth && ajaxUrl ) {
+		setupRepoAutocomplete( repoInput );
+		repoInput.addEventListener( 'change', onRepoInputChange );
+		repoInput.addEventListener( 'blur', onRepoInputChange );
+	}
+
+	if ( branchInput && githubOauth && ajaxUrl ) {
+		setupBranchAutocomplete( branchInput );
+	}
+
+	/**
+	 * Wire up autocomplete on the repo URI input.
+	 *
+	 * @param {HTMLInputElement} input
+	 */
+	function setupRepoAutocomplete( input ) {
+		var list = document.createElement( 'ul' );
+		list.className = 'gu-autocomplete-list';
+		list.setAttribute( 'role', 'listbox' );
+		list.style.cssText = [
+			'position:absolute',
+			'background:#fff',
+			'border:1px solid #8c8f94',
+			'border-top:none',
+			'border-radius:0 0 3px 3px',
+			'list-style:none',
+			'margin:0',
+			'padding:0',
+			'z-index:9999',
+			'min-width:350px',
+			'max-height:200px',
+			'overflow-y:auto',
+			'box-shadow:0 2px 6px rgba(0,0,0,.15)',
+		].join( ';' );
+		input.setAttribute( 'role', 'combobox' );
+		input.setAttribute( 'aria-autocomplete', 'list' );
+		input.setAttribute( 'aria-expanded', 'false' );
+		input.setAttribute( 'aria-haspopup', 'listbox' );
+		input.parentNode.style.position = 'relative';
+		input.parentNode.insertBefore( list, input.nextSibling );
+
+		var debounceTimer = null;
+		var activeIndex   = -1;
+
+		function closeList() {
+			list.innerHTML = '';
+			list.style.display = 'none';
+			input.setAttribute( 'aria-expanded', 'false' );
+			input.removeAttribute( 'aria-activedescendant' );
+			activeIndex = -1;
+		}
+
+		function setActive( index ) {
+			var items = list.querySelectorAll( 'li' );
+			if ( ! items.length ) {
+				return;
+			}
+			activeIndex = Math.max( -1, Math.min( index, items.length - 1 ) );
+			items.forEach( function ( item, i ) {
+				var on = i === activeIndex;
+				item.style.background = on ? '#2271b1' : '';
+				item.style.color      = on ? '#fff' : '';
+				item.setAttribute( 'aria-selected', on ? 'true' : 'false' );
+			} );
+			if ( activeIndex >= 0 ) {
+				var activeId = 'gu-repo-option-' + activeIndex;
+				items[ activeIndex ].id = activeId;
+				input.setAttribute( 'aria-activedescendant', activeId );
+				items[ activeIndex ].scrollIntoView( { block: 'nearest' } );
+			} else {
+				input.removeAttribute( 'aria-activedescendant' );
+			}
+		}
+
+		input.addEventListener( 'input', function () {
+			clearTimeout( debounceTimer );
+			var query = this.value.trim();
+			activeIndex = -1;
+			showSpinner( list, input );
+			debounceTimer = setTimeout(
+				function () {
+					fetchRepos(
+						query,
+						function ( repos ) {
+							renderAutocomplete( list, repos, input );
+						}
+					);
+				},
+				250
+			);
+		} );
+
+		input.addEventListener( 'keydown', function ( e ) {
+			var items = list.querySelectorAll( 'li' );
+			if ( ! items.length || list.style.display === 'none' ) {
+				return;
+			}
+			if ( e.key === 'ArrowDown' ) {
+				e.preventDefault();
+				setActive( activeIndex + 1 );
+			} else if ( e.key === 'ArrowUp' ) {
+				e.preventDefault();
+				setActive( activeIndex - 1 );
+			} else if ( e.key === 'Enter' ) {
+				if ( activeIndex >= 0 && items[ activeIndex ] && items[ activeIndex ]._guRepo ) {
+					e.preventDefault();
+					selectRepo( input, list, items[ activeIndex ]._guRepo );
+					activeIndex = -1;
+				}
+			} else if ( e.key === 'Escape' ) {
+				closeList();
+			}
+		} );
+
+		// Close list on outside click.
+		document.addEventListener( 'click', function ( e ) {
+			if ( e.target !== input ) {
+				closeList();
+			}
+		} );
+
+		/**
+		 * Render autocomplete dropdown items.
+		 *
+		 * @param {HTMLUListElement} listEl
+		 * @param {Array}            repos
+		 * @param {HTMLInputElement} inputEl
+		 */
+		function renderAutocomplete( listEl, repos, inputEl ) {
+			listEl.innerHTML = '';
+			activeIndex = -1;
+			if ( ! repos.length ) {
+				listEl.style.display = 'none';
+				inputEl.setAttribute( 'aria-expanded', 'false' );
+				return;
+			}
+
+			repos.forEach( function ( repo, i ) {
+				var li = document.createElement( 'li' );
+				li.setAttribute( 'role', 'option' );
+				li.setAttribute( 'aria-selected', 'false' );
+				li.id      = 'gu-repo-option-' + i;
+				li._guRepo = repo;
+
+				li.textContent = repo.full_name + ( repo.private ? ' 🔒' : '' );
+				li.style.cssText = 'padding:6px 10px;cursor:pointer;font-size:13px;border-bottom:1px solid #f0f0f1;';
+
+				li.addEventListener( 'mouseover', function () {
+					if ( li !== list.querySelectorAll( 'li' )[ activeIndex ] ) {
+						this.style.background = '#f6f7f7';
+						this.style.color      = '';
+					}
+				} );
+				li.addEventListener( 'mouseout', function () {
+					if ( li !== list.querySelectorAll( 'li' )[ activeIndex ] ) {
+						this.style.background = '';
+					}
+				} );
+				li.addEventListener( 'mousedown', function ( e ) {
+					e.preventDefault(); // prevent blur before click.
+					selectRepo( inputEl, listEl, repo );
+					activeIndex = -1;
+				} );
+				listEl.appendChild( li );
+			} );
+
+			listEl.style.display = 'block';
+			inputEl.setAttribute( 'aria-expanded', 'true' );
+		}
+	}
+
+	/**
+	 * Fetch matching repos from the AJAX endpoint.
+	 *
+	 * @param {string}   query
+	 * @param {Function} callback
+	 */
+	function fetchRepos( query, callback ) {
+		var url = ajaxUrl + '?action=gu_github_repos&nonce=' + encodeURIComponent( ajaxNonce ) + '&q=' + encodeURIComponent( query );
+		var xhr = new XMLHttpRequest();
+		xhr.open( 'GET', url, true );
+		xhr.onreadystatechange = function () {
+			if ( xhr.readyState === 4 && xhr.status === 200 ) {
+				try {
+					var data = JSON.parse( xhr.responseText );
+					if ( data.success && Array.isArray( data.data ) ) {
+						callback( data.data );
+					}
+				} catch (e) {}
+			}
+		};
+		xhr.send();
+	}
+
+	/**
+	 * Fill the URI field and trigger downstream autofill when a repo is selected.
+	 *
+	 * @param {HTMLInputElement} input
+	 * @param {HTMLUListElement} list
+	 * @param {Object}           repo
+	 */
+	function selectRepo( input, list, repo ) {
+		input.value = repo.html_url;
+		list.innerHTML = '';
+		list.style.display = 'none';
+		input.setAttribute( 'aria-expanded', 'false' );
+		input.removeAttribute( 'aria-activedescendant' );
+		applyConnectedRepoState( repo.html_url, repo.default_branch );
+	}
+
+	/**
+	 * Wire up branch name autocomplete on the branch input.
+	 *
+	 * @param {HTMLInputElement} input
+	 */
+	function setupBranchAutocomplete( input ) {
+		var list = document.createElement( 'ul' );
+		list.className = 'gu-autocomplete-list gu-branch-list';
+		list.setAttribute( 'role', 'listbox' );
+		list.style.cssText = [
+			'position:absolute',
+			'background:#fff',
+			'border:1px solid #8c8f94',
+			'border-top:none',
+			'border-radius:0 0 3px 3px',
+			'list-style:none',
+			'margin:0',
+			'padding:0',
+			'z-index:9999',
+			'min-width:220px',
+			'max-height:180px',
+			'overflow-y:auto',
+			'box-shadow:0 2px 6px rgba(0,0,0,.15)',
+		].join( ';' );
+		input.setAttribute( 'role', 'combobox' );
+		input.setAttribute( 'aria-autocomplete', 'list' );
+		input.setAttribute( 'aria-expanded', 'false' );
+		input.setAttribute( 'aria-haspopup', 'listbox' );
+		input.parentNode.style.position = 'relative';
+		input.parentNode.insertBefore( list, input.nextSibling );
+
+		var debounceTimer = null;
+		var activeIndex   = -1;
+
+		function closeList() {
+			list.innerHTML = '';
+			list.style.display = 'none';
+			input.setAttribute( 'aria-expanded', 'false' );
+			input.removeAttribute( 'aria-activedescendant' );
+			activeIndex = -1;
+		}
+
+		function setActive( index ) {
+			var items = list.querySelectorAll( 'li' );
+			if ( ! items.length ) {
+				return;
+			}
+			activeIndex = Math.max( -1, Math.min( index, items.length - 1 ) );
+			items.forEach( function ( item, i ) {
+				var on = i === activeIndex;
+				item.style.background = on ? '#2271b1' : '';
+				item.style.color      = on ? '#fff' : '';
+				item.setAttribute( 'aria-selected', on ? 'true' : 'false' );
+			} );
+			if ( activeIndex >= 0 ) {
+				var activeId = 'gu-branch-option-' + activeIndex;
+				items[ activeIndex ].id = activeId;
+				input.setAttribute( 'aria-activedescendant', activeId );
+				items[ activeIndex ].scrollIntoView( { block: 'nearest' } );
+			} else {
+				input.removeAttribute( 'aria-activedescendant' );
+			}
+		}
+
+		input.addEventListener( 'input', function () {
+			clearTimeout( debounceTimer );
+			var ownerRepo = extractOwnerRepo( repoInput ? repoInput.value : '' );
+			if ( ! ownerRepo ) {
+				closeList();
+				return;
+			}
+			var query = this.value.trim();
+			activeIndex = -1;
+			showSpinner( list, input );
+			debounceTimer = setTimeout(
+				function () {
+					fetchBranches(
+						ownerRepo,
+						function ( branches ) {
+							renderBranchList( list, branches, query, input );
+						}
+					);
+				},
+				250
+			);
+		} );
+
+		input.addEventListener( 'keydown', function ( e ) {
+			var items = list.querySelectorAll( 'li' );
+			if ( ! items.length || list.style.display === 'none' ) {
+				return;
+			}
+			if ( e.key === 'ArrowDown' ) {
+				e.preventDefault();
+				setActive( activeIndex + 1 );
+			} else if ( e.key === 'ArrowUp' ) {
+				e.preventDefault();
+				setActive( activeIndex - 1 );
+			} else if ( e.key === 'Enter' ) {
+				if ( activeIndex >= 0 && items[ activeIndex ] && items[ activeIndex ]._guBranch ) {
+					e.preventDefault();
+					input.value = items[ activeIndex ]._guBranch;
+					closeList();
+				}
+			} else if ( e.key === 'Escape' ) {
+				closeList();
+			}
+		} );
+
+		document.addEventListener( 'click', function ( e ) {
+			if ( e.target !== input ) {
+				closeList();
+			}
+		} );
+
+		/**
+		 * Render filtered branch list dropdown.
+		 *
+		 * @param {HTMLUListElement} listEl
+		 * @param {string[]}         branches
+		 * @param {string}           query
+		 * @param {HTMLInputElement} inputEl
+		 */
+		function renderBranchList( listEl, branches, query, inputEl ) {
+			listEl.innerHTML = '';
+			activeIndex = -1;
+			var filtered = query
+				? branches.filter( function ( b ) { return b.toLowerCase().indexOf( query.toLowerCase() ) !== -1; } )
+				: branches;
+
+			if ( ! filtered.length ) {
+				listEl.style.display = 'none';
+				inputEl.setAttribute( 'aria-expanded', 'false' );
+				return;
+			}
+
+			filtered.forEach( function ( branch, i ) {
+				var li = document.createElement( 'li' );
+				li.textContent = branch;
+				li.setAttribute( 'role', 'option' );
+				li.setAttribute( 'aria-selected', 'false' );
+				li.id        = 'gu-branch-option-' + i;
+				li._guBranch = branch;
+				li.style.cssText = 'padding:5px 10px;cursor:pointer;font-size:13px;border-bottom:1px solid #f0f0f1;';
+				li.addEventListener( 'mouseover', function () {
+					if ( i !== activeIndex ) {
+						this.style.background = '#f6f7f7';
+						this.style.color      = '';
+					}
+				} );
+				li.addEventListener( 'mouseout', function () {
+					if ( i !== activeIndex ) {
+						this.style.background = '';
+					}
+				} );
+				li.addEventListener( 'mousedown', function ( e ) {
+					e.preventDefault();
+					inputEl.value = branch;
+					closeList();
+				} );
+				listEl.appendChild( li );
+			} );
+			listEl.style.display = 'block';
+			inputEl.setAttribute( 'aria-expanded', 'true' );
+		}
+	}
+
+	/**
+	 * Fetch branches for owner/repo from AJAX endpoint.
+	 *
+	 * @param {string}   ownerRepo
+	 * @param {Function} callback
+	 */
+	function fetchBranches( ownerRepo, callback ) {
+		var url = ajaxUrl + '?action=gu_github_branches&nonce=' + encodeURIComponent( ajaxNonce ) + '&repo=' + encodeURIComponent( ownerRepo );
+		var xhr = new XMLHttpRequest();
+		xhr.open( 'GET', url, true );
+		xhr.onreadystatechange = function () {
+			if ( xhr.readyState === 4 && xhr.status === 200 ) {
+				try {
+					var data = JSON.parse( xhr.responseText );
+					if ( data.success && Array.isArray( data.data ) ) {
+						callback( data.data );
+					}
+				} catch (e) {}
+			}
+		};
+		xhr.send();
+	}
+
+	/**
+	 * Handle repo URI field change: autofill branch + toggle connected-account UI state.
+	 */
+	function onRepoInputChange() {
+		var uri = repoInput.value.trim();
+		if ( ! uri ) {
+			return;
+		}
+		applyConnectedRepoState( uri, null );
+	}
+
+	/**
+	 * Given a URI, determine if it belongs to the connected account.
+	 * If so: autofill the default branch (if not already set), select 'github'
+	 * in the host dropdown, and hide the host + token fields.
+	 *
+	 * @param {string}      uri
+	 * @param {string|null} knownDefaultBranch Pass when already known (e.g. from autocomplete selection).
+	 */
+	function applyConnectedRepoState( uri, knownDefaultBranch ) {
+		var ownerRepo = extractOwnerRepo( uri );
+		if ( ! ownerRepo ) {
+			showHostAndTokenFields();
+			return;
+		}
+
+		var owner = ownerRepo.split( '/' )[0];
+		var isConnectedRepo = githubUser && (
+			owner.toLowerCase() === githubUser.toLowerCase() ||
+			githubOrgs.indexOf( owner.toLowerCase() ) !== -1
+		);
+
+		if ( ! isConnectedRepo ) {
+			showHostAndTokenFields();
+			return;
+		}
+
+		// Set the host dropdown to 'github' if present, triggering its change handler
+		// to show/hide API-specific token fields for other hosts.
+		var apiSelect = document.getElementById( 'git_updater_api' );
+		if ( apiSelect ) {
+			apiSelect.value = 'github';
+			var evt = document.createEvent( 'HTMLEvents' );
+			evt.initEvent( 'change', true, false );
+			apiSelect.dispatchEvent( evt );
+		}
+
+		// Hide host/token fields AFTER the change event (which would re-show github rows).
+		hideHostAndTokenFields();
+
+		// Autofill branch from known value or fetch.
+		if ( knownDefaultBranch !== null ) {
+			maybeSetBranch( knownDefaultBranch );
+		} else {
+			fetchRepoInfo(
+				ownerRepo,
+				function ( info ) {
+					maybeSetBranch( info.default_branch );
+				}
+			);
+		}
+	}
+
+	/**
+	 * Set branch field to defaultBranch if the field is empty or set to 'master'
+	 * and defaultBranch differs from 'master'.
+	 *
+	 * @param {string} defaultBranch
+	 */
+	function maybeSetBranch( defaultBranch ) {
+		if ( ! branchInput || ! defaultBranch ) {
+			return;
+		}
+		var current = branchInput.value.trim();
+		if ( ( current === '' || current === 'master' ) && defaultBranch !== 'master' ) {
+			branchInput.value = defaultBranch;
+		}
+	}
+
+	/**
+	 * Fetch repo info (default_branch, etc.) from AJAX.
+	 *
+	 * @param {string}   ownerRepo
+	 * @param {Function} callback
+	 */
+	function fetchRepoInfo( ownerRepo, callback ) {
+		var url = ajaxUrl + '?action=gu_github_repo_info&nonce=' + encodeURIComponent( ajaxNonce ) + '&repo=' + encodeURIComponent( ownerRepo );
+		var xhr = new XMLHttpRequest();
+		xhr.open( 'GET', url, true );
+		xhr.onreadystatechange = function () {
+			if ( xhr.readyState === 4 && xhr.status === 200 ) {
+				try {
+					var data = JSON.parse( xhr.responseText );
+					if ( data.success && data.data ) {
+						callback( data.data );
+					}
+				} catch (e) {}
+			}
+		};
+		xhr.send();
+	}
+
+	/**
+	 * Extract "owner/repo" from a GitHub URI or bare "owner/repo" string.
+	 *
+	 * Handles:
+	 *   https://github.com/owner/repo
+	 *   https://github.com/owner/repo.git
+	 *   owner/repo
+	 *
+	 * @param  {string} uri
+	 * @return {string|null}
+	 */
+	function extractOwnerRepo( uri ) {
+		if ( ! uri ) {
+			return null;
+		}
+		uri = uri.trim().replace( /\.git$/, '' );
+
+		// Full GitHub URL.
+		var m = uri.match( /github\.com\/([^\/]+\/[^\/]+)/ );
+		if ( m ) {
+			return m[1];
+		}
+
+		// Bare owner/repo.
+		if ( /^[^\/\s]+\/[^\/\s]+$/.test( uri ) ) {
+			return uri;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Hide the Remote Repository Host and GitHub Access Token rows.
+	 */
+	function hideHostAndTokenFields() {
+		setFieldRowVisibility( 'git_updater_api', 'none' );
+		setFieldRowVisibility( 'github_access_token', 'none' );
+	}
+
+	/**
+	 * Restore visibility of the Remote Repository Host and GitHub Access Token rows.
+	 */
+	function showHostAndTokenFields() {
+		setFieldRowVisibility( 'git_updater_api', '' );
+		setFieldRowVisibility( 'github_access_token', '' );
+	}
+
+	/**
+	 * Set the display of the <tr> that wraps a given field ID.
+	 *
+	 * @param {string} fieldId
+	 * @param {string} display CSS display value.
+	 */
+	function setFieldRowVisibility( fieldId, display ) {
+		var el = document.getElementById( fieldId );
+		if ( ! el ) {
+			return;
+		}
+		var row = el.closest( 'tr' );
+		if ( row ) {
+			row.style.display = display;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Utility helpers (preserved from original)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Show a loading spinner inside an autocomplete list.
+	 *
+	 * @param {HTMLUListElement} listEl
+	 * @param {HTMLInputElement} inputEl
+	 */
+	function showSpinner( listEl, inputEl ) {
+		listEl.innerHTML = '';
+		var li = document.createElement( 'li' );
+		li.setAttribute( 'aria-live', 'polite' );
+		li.style.cssText = 'padding:8px 10px;font-size:13px;color:#646970;display:flex;align-items:center;gap:8px;';
+
+		var spinner = document.createElement( 'span' );
+		spinner.setAttribute( 'aria-hidden', 'true' );
+		spinner.style.cssText = [
+			'display:inline-block',
+			'width:14px',
+			'height:14px',
+			'border:2px solid #c3c4c7',
+			'border-top-color:#2271b1',
+			'border-radius:50%',
+			'animation:gu-spin .6s linear infinite',
+			'flex-shrink:0',
+		].join( ';' );
+
+		// Inject keyframes once.
+		if ( ! document.getElementById( 'gu-spin-style' ) ) {
+			var style = document.createElement( 'style' );
+			style.id = 'gu-spin-style';
+			style.textContent = '@keyframes gu-spin{to{transform:rotate(360deg)}}';
+			document.head.appendChild( style );
+		}
+
+		li.appendChild( spinner );
+		li.appendChild( document.createTextNode( 'Searching\u2026' ) );
+		listEl.appendChild( li );
+		listEl.style.display = 'block';
+		inputEl.setAttribute( 'aria-expanded', 'true' );
 	}
 
 	// Remove selected element from array and return array.

--- a/src/Git_Updater/Install.php
+++ b/src/Git_Updater/Install.php
@@ -14,6 +14,7 @@
 namespace Fragen\Git_Updater;
 
 use Fragen\Singleton;
+use Fragen\Git_Updater\OAuth\OAuth_Connect;
 use Fragen\Git_Updater\Traits\GU_Trait;
 use Fragen\Git_Updater\Traits\Basic_Auth_Loader;
 use Fragen\Git_Updater\WP_CLI\CLI_Plugin_Installer_Skin;
@@ -100,6 +101,23 @@ class Install {
 			function () {
 				wp_register_script( 'gu-install', plugins_url( basename( dirname( __DIR__, 2 ) ) . '/js/gu-install-vanilla.js' ), [], $this->get_plugin_version(), true );
 				wp_enqueue_script( 'gu-install' );
+
+				$oauth           = Singleton::get_instance( 'Fragen\Git_Updater\OAuth\OAuth_Connect', $this );
+				$github_oauth    = $oauth->is_oauth_token( 'github' );
+				$github_username = $github_oauth ? $this->get_github_username() : '';
+				$github_orgs     = $github_oauth ? $this->get_github_org_logins() : [];
+
+				wp_localize_script(
+					'gu-install',
+					'guInstallData',
+					[
+						'ajaxurl'         => admin_url( 'admin-ajax.php' ),
+						'nonce'           => wp_create_nonce( 'gu_github_install_autocomplete' ),
+						'github_oauth'    => $github_oauth ? '1' : '0',
+						'github_username' => $github_username,
+						'github_orgs'     => $github_orgs,
+					]
+				);
 			}
 		);
 	}
@@ -531,5 +549,351 @@ class Install {
 		ksort( $install_actions );
 
 		return $install_actions;
+	}
+
+	/**
+	 * Register AJAX handlers for GitHub install autocomplete.
+	 *
+	 * @return void
+	 */
+	public function register_ajax_handlers(): void {
+		add_action( 'wp_ajax_gu_github_repos', [ $this, 'ajax_github_repos' ] );
+		add_action( 'wp_ajax_gu_github_branches', [ $this, 'ajax_github_branches' ] );
+		add_action( 'wp_ajax_gu_github_repo_info', [ $this, 'ajax_github_repo_info' ] );
+	}
+
+	/**
+	 * AJAX handler: return GitHub repos matching a search query.
+	 *
+	 * Returns repos from the connected GitHub account whose full_name contains
+	 * the query string. Results are cached in a site transient for 5 minutes.
+	 *
+	 * @return void
+	 */
+	public function ajax_github_repos(): void {
+		check_ajax_referer( 'gu_github_install_autocomplete', 'nonce' );
+
+		if ( ! current_user_can( 'install_plugins' ) && ! current_user_can( 'install_themes' ) ) {
+			wp_send_json_error( 'Forbidden', 403 );
+		}
+
+		$options = get_site_option( 'git_updater', [] );
+		$token   = $options['github_access_token'] ?? '';
+
+		if ( ! $token ) {
+			wp_send_json_success( [] );
+		}
+
+		$search = sanitize_text_field( wp_unslash( $_GET['q'] ?? '' ) );
+
+		// Attempt to serve from transient cache.
+		$cache_key  = 'gu_github_repos_' . md5( $token );
+		$all_repos  = get_site_transient( $cache_key );
+
+		if ( false === $all_repos ) {
+			$all_repos = $this->fetch_all_github_repos( $token );
+			set_site_transient( $cache_key, $all_repos, 5 * MINUTE_IN_SECONDS );
+		}
+
+		if ( ! is_array( $all_repos ) ) {
+			wp_send_json_success( [] );
+		}
+
+		$results = [];
+		foreach ( $all_repos as $repo ) {
+			if ( empty( $search ) || stripos( $repo['full_name'], $search ) !== false || stripos( $repo['name'], $search ) !== false ) {
+				$results[] = [
+					'full_name'      => $repo['full_name'],
+					'html_url'       => $repo['html_url'],
+					'default_branch' => $repo['default_branch'],
+					'private'        => $repo['private'],
+				];
+				if ( count( $results ) >= 20 ) {
+					break;
+				}
+			}
+		}
+
+		wp_send_json_success( $results );
+	}
+
+	/**
+	 * AJAX handler: return branch list for a given owner/repo.
+	 *
+	 * @return void
+	 */
+	public function ajax_github_branches(): void {
+		check_ajax_referer( 'gu_github_install_autocomplete', 'nonce' );
+
+		if ( ! current_user_can( 'install_plugins' ) && ! current_user_can( 'install_themes' ) ) {
+			wp_send_json_error( 'Forbidden', 403 );
+		}
+
+		$options    = get_site_option( 'git_updater', [] );
+		$token      = $options['github_access_token'] ?? '';
+		$owner_repo = sanitize_text_field( wp_unslash( $_GET['repo'] ?? '' ) );
+
+		if ( ! $token || ! $owner_repo || ! preg_match( '/^[^\/]+\/[^\/]+$/', $owner_repo ) ) {
+			wp_send_json_success( [] );
+		}
+
+		$cache_key = 'gu_github_branches_' . md5( $token . $owner_repo );
+		$branches  = get_site_transient( $cache_key );
+
+		if ( false === $branches ) {
+			$url      = 'https://api.github.com/repos/' . $owner_repo . '/branches';
+			$url      = add_query_arg( 'per_page', '100', $url );
+			$response = wp_remote_get(
+				$url,
+				[
+					'headers' => [
+						'Authorization' => 'Bearer ' . $token,
+						'Accept'        => 'application/vnd.github.v3+json',
+					],
+					'timeout' => 10,
+				]
+			);
+
+			$branches = [];
+			if ( ! is_wp_error( $response ) && 200 === (int) wp_remote_retrieve_response_code( $response ) ) {
+				$body = json_decode( wp_remote_retrieve_body( $response ), true );
+				if ( is_array( $body ) ) {
+					foreach ( $body as $branch ) {
+						$branches[] = $branch['name'] ?? '';
+					}
+					$branches = array_filter( $branches );
+				}
+			}
+			set_site_transient( $cache_key, $branches, 5 * MINUTE_IN_SECONDS );
+		}
+
+		wp_send_json_success( array_values( $branches ) );
+	}
+
+	/**
+	 * AJAX handler: return default branch for a given owner/repo.
+	 *
+	 * Used to auto-populate the branch field when a connected-account repo
+	 * is entered in the URI field.
+	 *
+	 * @return void
+	 */
+	public function ajax_github_repo_info(): void {
+		check_ajax_referer( 'gu_github_install_autocomplete', 'nonce' );
+
+		if ( ! current_user_can( 'install_plugins' ) && ! current_user_can( 'install_themes' ) ) {
+			wp_send_json_error( 'Forbidden', 403 );
+		}
+
+		$options    = get_site_option( 'git_updater', [] );
+		$token      = $options['github_access_token'] ?? '';
+		$owner_repo = sanitize_text_field( wp_unslash( $_GET['repo'] ?? '' ) );
+
+		if ( ! $token || ! $owner_repo || ! preg_match( '/^[^\/]+\/[^\/]+$/', $owner_repo ) ) {
+			wp_send_json_error( 'Invalid input' );
+		}
+
+		$cache_key = 'gu_github_repo_info_' . md5( $token . $owner_repo );
+		$info      = get_site_transient( $cache_key );
+
+		if ( false === $info ) {
+			$url      = 'https://api.github.com/repos/' . $owner_repo;
+			$response = wp_remote_get(
+				$url,
+				[
+					'headers' => [
+						'Authorization' => 'Bearer ' . $token,
+						'Accept'        => 'application/vnd.github.v3+json',
+					],
+					'timeout' => 10,
+				]
+			);
+
+			if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+				wp_send_json_error( 'API error' );
+			}
+
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+			if ( ! is_array( $body ) ) {
+				wp_send_json_error( 'Invalid response' );
+			}
+
+			$info = [
+				'default_branch' => $body['default_branch'] ?? 'master',
+				'private'        => $body['private'] ?? false,
+				'owner'          => $body['owner']['login'] ?? '',
+			];
+			set_site_transient( $cache_key, $info, 5 * MINUTE_IN_SECONDS );
+		}
+
+		wp_send_json_success( $info );
+	}
+
+	/**
+	 * Fetch all repos for the authenticated GitHub user, including organization repos (paginated).
+	 *
+	 * Queries /user/repos for personal and directly-accessible repos, then /user/orgs
+	 * to enumerate all organizations and fetches each org's repos separately.
+	 * Results are deduplicated by full_name.
+	 *
+	 * @param string $token GitHub access token.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function fetch_all_github_repos( string $token ): array {
+		$headers = [
+			'Authorization' => 'Bearer ' . $token,
+			'Accept'        => 'application/vnd.github.v3+json',
+		];
+
+		// Fetch user repos (personal + repos the user has direct access to).
+		$all_repos = $this->github_paginate( 'https://api.github.com/user/repos', [ 'type' => 'all', 'sort' => 'pushed' ], $headers );
+
+		// Fetch all orgs the user belongs to.
+		$orgs = $this->github_paginate( 'https://api.github.com/user/orgs', [], $headers );
+
+		// For each org, fetch its repos and merge.
+		foreach ( $orgs as $org ) {
+			$org_login  = $org['login'] ?? '';
+			if ( ! $org_login ) {
+				continue;
+			}
+			$org_repos = $this->github_paginate(
+				'https://api.github.com/orgs/' . rawurlencode( $org_login ) . '/repos',
+				[ 'type' => 'all', 'sort' => 'pushed' ],
+				$headers
+			);
+			$all_repos = array_merge( $all_repos, $org_repos );
+		}
+
+		// Deduplicate by full_name.
+		$seen      = [];
+		$unique    = [];
+		foreach ( $all_repos as $repo ) {
+			$key = $repo['full_name'] ?? '';
+			if ( $key && ! isset( $seen[ $key ] ) ) {
+				$seen[ $key ] = true;
+				$unique[]     = $repo;
+			}
+		}
+
+		return $unique;
+	}
+
+	/**
+	 * Paginate a GitHub API endpoint and return all results (capped at 1000 items).
+	 *
+	 * @param string                         $base_url Base API URL without query args.
+	 * @param array<string, mixed>           $params   Extra query parameters.
+	 * @param array<string, string>          $headers  HTTP headers (including Authorization).
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function github_paginate( string $base_url, array $params, array $headers ): array {
+		$results = [];
+		$page    = 1;
+
+		do {
+			$url      = add_query_arg( array_merge( $params, [ 'per_page' => 100, 'page' => $page ] ), $base_url );
+			$response = wp_remote_get( $url, [ 'headers' => $headers, 'timeout' => 10 ] );
+
+			if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+				break;
+			}
+
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+			if ( ! is_array( $body ) || empty( $body ) ) {
+				break;
+			}
+
+			$results = array_merge( $results, $body );
+			$page++;
+		} while ( count( $body ) === 100 && count( $results ) < 1000 );
+
+		return $results;
+	}
+
+	/**
+	 * Get the GitHub username for the connected OAuth account.
+	 *
+	 * Result is cached in a site transient for 1 hour.
+	 *
+	 * @return string Username or empty string on failure.
+	 */
+	private function get_github_username(): string {
+		$options = get_site_option( 'git_updater', [] );
+		$token   = $options['github_access_token'] ?? '';
+
+		if ( ! $token ) {
+			return '';
+		}
+
+		$cache_key = 'gu_github_username_' . md5( $token );
+		$username  = get_site_transient( $cache_key );
+
+		if ( false !== $username ) {
+			return (string) $username;
+		}
+
+		$response = wp_remote_get(
+			'https://api.github.com/user',
+			[
+				'headers' => [
+					'Authorization' => 'Bearer ' . $token,
+					'Accept'        => 'application/vnd.github.v3+json',
+				],
+				'timeout' => 5,
+			]
+		);
+
+		if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			return '';
+		}
+
+		$body     = json_decode( wp_remote_retrieve_body( $response ), true );
+		$username = is_array( $body ) ? ( $body['login'] ?? '' ) : '';
+
+		set_site_transient( $cache_key, $username, HOUR_IN_SECONDS );
+
+		return (string) $username;
+	}
+
+	/**
+	 * Get the login slugs of all GitHub organizations the authenticated user belongs to.
+	 *
+	 * Result is cached in a site transient for 1 hour.
+	 *
+	 * @return list<string>
+	 */
+	private function get_github_org_logins(): array {
+		$options = get_site_option( 'git_updater', [] );
+		$token   = $options['github_access_token'] ?? '';
+
+		if ( ! $token ) {
+			return [];
+		}
+
+		$cache_key = 'gu_github_orgs_' . md5( $token );
+		$orgs      = get_site_transient( $cache_key );
+
+		if ( false !== $orgs ) {
+			return is_array( $orgs ) ? $orgs : [];
+		}
+
+		$headers = [
+			'Authorization' => 'Bearer ' . $token,
+			'Accept'        => 'application/vnd.github.v3+json',
+		];
+
+		$raw_orgs = $this->github_paginate( 'https://api.github.com/user/orgs', [], $headers );
+
+		$logins = [];
+		foreach ( $raw_orgs as $org ) {
+			if ( ! empty( $org['login'] ) ) {
+				$logins[] = strtolower( $org['login'] );
+			}
+		}
+
+		set_site_transient( $cache_key, $logins, HOUR_IN_SECONDS );
+
+		return $logins;
 	}
 }

--- a/src/Git_Updater/Settings.php
+++ b/src/Git_Updater/Settings.php
@@ -103,6 +103,8 @@ class Settings {
 	 * @return void
 	 */
 	protected function load_hooks() {
+		// Always register Install AJAX handlers so they work during wp-ajax requests.
+		Singleton::get_instance( 'Install', $this )->register_ajax_handlers();
 		if ( ! (bool) apply_filters( 'gu_hide_settings', false ) ) {
 			add_action( is_multisite() ? 'network_admin_menu' : 'admin_menu', [ $this, 'add_plugin_page' ] );
 		}


### PR DESCRIPTION
This is totally just an initial proof of concept... but I thought once we have oAuth connection to an account, we can relieve some of the tediousness of having to locate and copy and paste the exact github.com repo URL, remember the exact branch name and if it's master or main for the primary, etc. 

This code is fully Claude generated and should be human reviewed and tested in more detail before merging.

I think this would be a great enhancement and make installing private plugins and themes way faster and more enjoyable!

<img width="974" height="433" alt="2026-07-13 13 57 34" src="https://github.com/user-attachments/assets/3e3163bd-eb2d-452f-a77c-fd464473e996" />
